### PR TITLE
Expose what a host needs to place frames from Python (LS-50 and probably 5000 too)

### DIFF
--- a/nkscan.pyi
+++ b/nkscan.pyi
@@ -145,13 +145,24 @@ class Session:
         r"""
         Whether there is film in the scanner now
         """
-    def prepare(self, *, frames: typing.Optional[builtins.int] = None, detect: builtins.bool = False, pitch_mm: typing.Optional[builtins.float] = None, offset_mm: builtins.float = 0.0, gain: typing.Optional[typing.Sequence[builtins.int]] = None, lock_white_balance: builtins.bool = False, wait_for_media_s: builtins.float = 300.0, progress: collections.abc.Callable[[int, int], bool | None] | None = None) -> builtins.int:
+    def sensed_frames(self) -> typing.Optional[builtins.int]:
+        r"""
+        How many frames the loaded holder reports, `None` where the model cannot be asked
+        
+        A vendor page read rather than a pass, so it answers before the mechanism moves — and on
+        the models that clear it as the film advances, before the first pass is the only time it
+        means anything. `0` is an empty transport, which is not the same answer as `None`.
+        """
+    def prepare(self, *, frames: typing.Optional[builtins.int] = None, detect: builtins.bool = False, pitch_mm: typing.Optional[builtins.float] = None, offset_mm: builtins.float = 0.0, offsets_mm: typing.Optional[typing.Sequence[builtins.float]] = None, gain: typing.Optional[typing.Sequence[builtins.int]] = None, lock_white_balance: builtins.bool = False, wait_for_media_s: builtins.float = 300.0, progress: collections.abc.Callable[[int, int], bool | None] | None = None) -> builtins.int:
         r"""
         Wake the mechanism, settle the exposure and place the frames, returning how many
         
         `detect` asks the scanner to find them with an overview pass, where it can. Otherwise they
         are placed at `pitch_mm`, or at whatever the loaded holder reports. `gain` as a 3- or
         4-tuple holds the exposure and skips metering.
+        
+        `offsets_mm` shifts each frame along the feed, the last value repeating down the strip, and
+        takes the place of `offset_mm` when both are given.
         """
     def scan(self, index: builtins.int = 0, *, dpi: builtins.int = 4000, ir: builtins.bool = False, focus: builtins.str = 'auto', multisample: builtins.int = 1, single_line: builtins.bool = False, window: typing.Optional[tuple[builtins.float, builtins.float, builtins.float, builtins.float]] = None, progress: collections.abc.Callable[[int, int], bool | None] | None = None) -> ScanResult:
         r"""

--- a/src/python.rs
+++ b/src/python.rs
@@ -178,6 +178,35 @@ fn into_arrays(py: Python<'_>, image: Image) -> PyResult<Planes> {
     Ok((rgb, ir))
 }
 
+/// How `prepare`'s arguments name one of the three ways frames get placed
+///
+/// Pitch is the fallback rather than Sensed: a model that reports no frame table refuses Sensed
+/// outright, so inferring it from absent arguments would make the default call the one shape such
+/// a model cannot run. Sensed is kept for the transports that do report one, and only while the
+/// caller has not overridden the placement with a pitch or an offset.
+fn placement_for(
+    capabilities: &DeviceCapabilities,
+    detected: Option<u32>,
+    frames: Option<u32>,
+    pitch_mm: Option<f32>,
+    offsets_mm: Vec<f32>,
+) -> Placement {
+    if let Some(frames) = detected {
+        return Placement::Detect {
+            frames: frames as usize,
+        };
+    }
+    let placed = pitch_mm.is_some() || offsets_mm.iter().any(|&offset| offset != 0.0);
+    if capabilities.senses_frames && !placed {
+        return Placement::Sensed { frames };
+    }
+    Placement::Pitch {
+        frames,
+        pitch_mm,
+        offsets_mm,
+    }
+}
+
 /// An exclusive hold on one scanner
 #[gen_stub_pyclass]
 #[pyclass(name = "Session", module = "nkscan")]
@@ -285,13 +314,25 @@ impl PySession {
         self.run(py, None, |session, _| session.media_loaded())
     }
 
+    /// How many frames the loaded holder reports, `None` where the model cannot be asked
+    ///
+    /// A vendor page read rather than a pass, so it answers before the mechanism moves — and on
+    /// the models that clear it as the film advances, before the first pass is the only time it
+    /// means anything. `0` is an empty transport, which is not the same answer as `None`.
+    fn sensed_frames(&self, py: Python<'_>) -> PyResult<Option<u32>> {
+        self.run(py, None, |session, _| Ok(session.sensed_frames()))
+    }
+
     /// Wake the mechanism, settle the exposure and place the frames, returning how many
     ///
     /// `detect` asks the scanner to find them with an overview pass, where it can. Otherwise they
     /// are placed at `pitch_mm`, or at whatever the loaded holder reports. `gain` as a 3- or
     /// 4-tuple holds the exposure and skips metering.
+    ///
+    /// `offsets_mm` shifts each frame along the feed, the last value repeating down the strip, and
+    /// takes the place of `offset_mm` when both are given.
     #[pyo3(signature = (
-        *, frames = None, detect = false, pitch_mm = None, offset_mm = 0.0,
+        *, frames = None, detect = false, pitch_mm = None, offset_mm = 0.0, offsets_mm = None,
         gain = None, lock_white_balance = false, wait_for_media_s = 300.0, progress = None,
     ))]
     #[allow(clippy::too_many_arguments)]
@@ -302,6 +343,7 @@ impl PySession {
         detect: bool,
         pitch_mm: Option<f32>,
         offset_mm: f32,
+        offsets_mm: Option<Vec<f32>>,
         gain: Option<Vec<u32>>,
         lock_white_balance: bool,
         wait_for_media_s: f64,
@@ -311,21 +353,14 @@ impl PySession {
         ))]
         progress: Option<Py<PyAny>>,
     ) -> PyResult<usize> {
-        let placement = if detect {
-            Placement::Detect {
-                frames: frames.ok_or_else(|| {
+        let offsets_mm = offsets_mm.unwrap_or_else(|| vec![offset_mm]);
+        let detected = detect
+            .then(|| {
+                frames.ok_or_else(|| {
                     PyValueError::new_err("detect needs frames, to say how many to look for")
-                })? as usize,
-            }
-        } else if pitch_mm.is_some() || offset_mm != 0.0 {
-            Placement::Pitch {
-                frames,
-                pitch_mm,
-                offsets_mm: vec![offset_mm],
-            }
-        } else {
-            Placement::Sensed { frames }
-        };
+                })
+            })
+            .transpose()?;
 
         let exposure = match gain {
             Some(values) if matches!(values.len(), 3 | 4) => Exposure::Fixed {
@@ -341,13 +376,23 @@ impl PySession {
             None => Exposure::Auto { lock_white_balance },
         };
 
-        let prepare = Prepare {
-            placement,
-            exposure,
-            wait_for_media: Duration::from_secs_f64(wait_for_media_s.max(0.0)),
-        };
+        let wait_for_media = Duration::from_secs_f64(wait_for_media_s.max(0.0));
         self.run(py, progress, |session, report| {
-            session.prepare(&prepare, report)
+            let placement = placement_for(
+                &session.capabilities(),
+                detected,
+                frames,
+                pitch_mm,
+                offsets_mm,
+            );
+            session.prepare(
+                &Prepare {
+                    placement,
+                    exposure,
+                    wait_for_media,
+                },
+                report,
+            )
         })
     }
 
@@ -490,3 +535,65 @@ fn nkscan_module(module: &Bound<'_, PyModule>) -> PyResult<()> {
 // Reads pyproject.toml for the module name, so `cargo run --bin stub_gen` writes the stub the
 // wheel ships
 define_stub_info_gatherer!(stub_info);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::devices::Model;
+
+    fn placement(model: Model, pitch_mm: Option<f32>, offsets_mm: Vec<f32>) -> Placement {
+        placement_for(&model.capabilities(), None, Some(6), pitch_mm, offsets_mm)
+    }
+
+    /// The LS-50 refuses Sensed, so the plain call has to reach Pitch
+    #[test]
+    fn a_model_that_senses_nothing_is_placed_by_pitch() {
+        assert_eq!(
+            placement(Model::Ls50, None, vec![0.0]),
+            Placement::Pitch {
+                frames: Some(6),
+                pitch_mm: None,
+                offsets_mm: vec![0.0],
+            }
+        );
+    }
+
+    #[test]
+    fn a_sensing_model_keeps_its_own_table() {
+        assert_eq!(
+            placement(Model::Ls5000, None, vec![0.0]),
+            Placement::Sensed { frames: Some(6) }
+        );
+    }
+
+    /// A pitch or an offset is a placement the caller chose, and outranks the sensed table
+    #[test]
+    fn an_explicit_placement_overrides_sensing() {
+        assert_eq!(
+            placement(Model::Ls5000, Some(38.0), vec![0.0]),
+            Placement::Pitch {
+                frames: Some(6),
+                pitch_mm: Some(38.0),
+                offsets_mm: vec![0.0],
+            }
+        );
+        assert!(matches!(
+            placement(Model::Ls5000, None, vec![0.0, 0.4]),
+            Placement::Pitch { .. }
+        ));
+    }
+
+    #[test]
+    fn detect_wins_wherever_it_is_asked_for() {
+        assert_eq!(
+            placement_for(
+                &Model::Ls9000.capabilities(),
+                Some(4),
+                Some(6),
+                Some(38.0),
+                vec![0.2],
+            ),
+            Placement::Detect { frames: 4 }
+        );
+    }
+}

--- a/src/session/ls50.rs
+++ b/src/session/ls50.rs
@@ -163,6 +163,10 @@ impl Driver for Ls50Driver {
         self.frames.0.len()
     }
 
+    fn sensed_frames(&mut self) -> Option<u32> {
+        Some(self.scanner.sensed_frames())
+    }
+
     fn scan_frame(
         &mut self,
         index: usize,

--- a/src/session/ls5000.rs
+++ b/src/session/ls5000.rs
@@ -167,6 +167,10 @@ impl Driver for Ls5000Driver {
         self.frames.0.len()
     }
 
+    fn sensed_frames(&mut self) -> Option<u32> {
+        Some(self.scanner.sensed_frames())
+    }
+
     fn scan_frame(
         &mut self,
         index: usize,

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -228,6 +228,10 @@ pub(crate) trait Driver: Send {
     fn prepare(&mut self, prepare: &Prepare, progress: &mut ProgressFn<'_>)
     -> Result<usize, Error>;
     fn frames(&self) -> usize;
+    /// How many frames the loaded holder reports, where the model can be asked
+    fn sensed_frames(&mut self) -> Option<u32> {
+        None
+    }
     fn scan_frame(
         &mut self,
         index: usize,
@@ -317,6 +321,15 @@ impl Session {
     /// How many frames [`prepare`](Self::prepare) placed
     pub fn frames(&self) -> usize {
         self.driver.frames()
+    }
+
+    /// How many frames the loaded holder reports, `None` where the model cannot be asked
+    ///
+    /// A cheap vendor page read, so this answers before anything mechanical happens — which is
+    /// also the only time it is worth trusting on the models that clear it as the film moves.
+    /// `Some(0)` is an empty transport, and is not the same answer as `None`.
+    pub fn sensed_frames(&mut self) -> Option<u32> {
+        self.driver.sensed_frames()
     }
 
     /// Focus, expose and scan one of the placed frames


### PR DESCRIPTION
Driving an LS-50 from a negp yran into three gaps in the binding.

### The frame count never reached Python

`Ls50::sensed_frames()` and `Ls5000::sensed_frames()` already read the count off the vendor page, and `prepare()` consumes it internally but a caller had no way to ask. Sizing a strip in a UI meant running a prepare pass first and reading its return, which is a mechanical operation just to fill in a spin box.

`Session::sensed_frames() -> Option<u32>` exposes it, `None` on a model that cannot be asked (LS-9000 finds frames with an overview pass instead). Kept as a method rather than folded into `Capabilities`, since it describes the loaded film rather than the model, and `capabilities.rs` already notes it must be read fresh.

Verified on an LS-50 ED with a six-frame strip loaded: `sensed_frames()` returns `6`.

### `prepare()` could not run at all on an LS-50

Placement was inferred from which arguments were absent:

```rust
} else if pitch_mm.is_some() || offset_mm != 0.0 { Placement::Pitch { .. } }
else { Placement::Sensed { frames } }
```

So `prepare()` with no placement arguments asked for `Sensed`, and `Ls50Driver` refuses that outright — *"this model neither senses frames nor has an overview pass; place them"*. The plainest possible call was the one shape that model cannot run, and the workaround was to pass a nonzero offset you did not want.

Pitch is now the fallback. `Sensed` is still chosen where the transport actually reports a table (`senses_frames`) and the caller has named no pitch or offset, so LS-5000 behaviour is unchanged.

The decision moved into `placement_for()` so it can be tested without an interpreter,  four cases cover the fallback, the sensing model, an explicit placement overriding it, and detect.

### Per-frame offsets stopped at the boundary

`Placement::Pitch` takes `offsets_mm: Vec<f32>` with the last value repeating, which is exactly what correcting progressive frame-gap drift along a strip needs. Python could pass only a scalar. `prepare()` now also accepts `offsets_mm` as a sequence, superseding `offset_mm` when both are given; `offset_mm` is untouched, so existing callers are unaffected.

### Checks

`cargo test --features python` — 331 pass (4 new). `cargo clippy --features python --all-targets` and `cargo fmt --check` clean. Stub regenerated via `cargo run --features python --bin stub_gen`.

AI Disclosure: Implemented using Opus 5