### PR TITLE
Add support for perforation framing with strip film adapters + fix LS-5x scanning flow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,7 @@ bitflags = "2"
 nusb = "0.2"
 tracing = "0.1"
 anyhow = "1"
-tracing-subscriber = { version = "0.3", features = [
-  "env-filter",
-] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Python library dependencies
 #
@@ -41,12 +39,7 @@ moxcms = { version = "0.9", optional = true }
 
 
 [features]
-cli = [
-  "dep:clap",
-  "dep:indicatif",
-  "dep:tiff",
-  "dep:moxcms",
-]
+cli = ["dep:clap", "dep:indicatif", "dep:tiff", "dep:moxcms"]
 python = ["dep:pyo3", "dep:numpy", "dep:pyo3-stub-gen"]
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ thiserror = "2"
 bitflags = "2"
 nusb = "0.2"
 tracing = "0.1"
+anyhow = "1"
+tracing-subscriber = { version = "0.3", features = [
+  "env-filter",
+] }
 
 # Python library dependencies
 #
@@ -30,11 +34,7 @@ pyo3-stub-gen = { version = "0.23", optional = true, default-features = false, f
 ] }
 
 # The CLI stack, which a library consumer has no use for
-tracing-subscriber = { version = "0.3", features = [
-  "env-filter",
-], optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
-anyhow = { version = "1", optional = true }
 indicatif = { version = "0.18", optional = true }
 tiff = { version = "0.11", optional = true }
 moxcms = { version = "0.9", optional = true }
@@ -42,9 +42,7 @@ moxcms = { version = "0.9", optional = true }
 
 [features]
 cli = [
-  "dep:tracing-subscriber",
   "dep:clap",
-  "dep:anyhow",
   "dep:indicatif",
   "dep:tiff",
   "dep:moxcms",

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ This library doesn't have anything scanner or adapter-specific so *theoretically
 |------------------|:------:|:---------:|:----------:|:------:|:-----------:|
 | 5000             |   ⚠️   |  ⚠️      |    ⚠️     |  ⚠️    |   ⚠️       |
 | 4000             |   ⚠️   |  ⚠️      |    ⚠️     |  ⚠️    |   ⚠️       |
-| V                |   ⚠️   |  ⚠️      |    ⚠️     |  ⚠️    |   ⚠️       |
+| V                |   ✅   |  ⚠️      |    ⚠️     |  ✅    |   ⚠️       |
 | IV               |   ⚠️   |  ⚠️      |    ⚠️     |  ⚠️    |   ⚠️       |
 
 If you want to use a Firewire scanner on an old Mac that still has OS support for FireWire, let me know and I can scope it out.

--- a/examples/trace.rs
+++ b/examples/trace.rs
@@ -22,7 +22,7 @@
 use std::{env, fs, path::PathBuf};
 
 use nkscan::protocol::{
-    data::{self, Boundary, PerfInformation, PerforationInformation},
+    data::{self, Boundary, PerfInformation},
     window::Window,
 };
 
@@ -118,19 +118,22 @@ fn main() -> anyhow::Result<()> {
                     }
                     None => println!("[{n}] seq={} FRAME BOUNDARY (unparseable)", r.seq),
                 }
-            },
+            }
             0x28 if dtc(r.cdb) == Some(0x8E) => {
-                match r.data.get(data::HEADER..).and_then(PerfInformation::from_bytes) {
+                match r
+                    .data
+                    .get(data::HEADER..)
+                    .and_then(PerfInformation::from_bytes)
+                {
                     Some(b) => {
-                        println!(
-                            "[{n}] seq={} PERF ({} frame(s))",
-                            r.seq,
-                            b.perfs.len()
-                        );
+                        println!("[{n}] seq={} PERF ({} frame(s))", r.seq, b.perfs.len());
                         for f in &b.perfs {
                             println!(
                                 "      perf num={} flag={} num_pat(decimal)={} num_pulse={}",
-                                f.perf_number, f.count_switching_flag, f.pattern_number, f.pulse_number
+                                f.perf_number,
+                                f.count_switching_flag,
+                                f.perf_number,
+                                f.pulse_number
                             );
                         }
                     }

--- a/examples/trace.rs
+++ b/examples/trace.rs
@@ -22,7 +22,7 @@
 use std::{env, fs, path::PathBuf};
 
 use nkscan::protocol::{
-    data::{self, Boundary},
+    data::{self, Boundary, PerfInformation, PerforationInformation},
     window::Window,
 };
 
@@ -117,6 +117,24 @@ fn main() -> anyhow::Result<()> {
                         }
                     }
                     None => println!("[{n}] seq={} FRAME BOUNDARY (unparseable)", r.seq),
+                }
+            },
+            0x28 if dtc(r.cdb) == Some(0x8E) => {
+                match r.data.get(data::HEADER..).and_then(PerfInformation::from_bytes) {
+                    Some(b) => {
+                        println!(
+                            "[{n}] seq={} PERF ({} frame(s))",
+                            r.seq,
+                            b.perfs.len()
+                        );
+                        for f in &b.perfs {
+                            println!(
+                                "      perf num={} flag={} num_pat(decimal)={} num_pulse={}",
+                                f.perf_number, f.count_switching_flag, f.num_pattern, f.pulse_number
+                            );
+                        }
+                    }
+                    None => println!("[{n}] seq={} PERF (unparseable)", r.seq),
                 }
             }
             _ => println!("[{n}] seq={} {}", r.seq, describe(r)),

--- a/examples/trace.rs
+++ b/examples/trace.rs
@@ -130,7 +130,7 @@ fn main() -> anyhow::Result<()> {
                         for f in &b.perfs {
                             println!(
                                 "      perf num={} flag={} num_pat(decimal)={} num_pulse={}",
-                                f.perf_number, f.count_switching_flag, f.num_pattern, f.pulse_number
+                                f.perf_number, f.count_switching_flag, f.pattern_number, f.pulse_number
                             );
                         }
                     }

--- a/src/bin/nkscan/cli.rs
+++ b/src/bin/nkscan/cli.rs
@@ -127,6 +127,7 @@ pub fn parse_log_level(flag: &str) -> Result<LevelFilter, String> {
 /// is what a format nobody named still needs
 pub fn parse_format(flag: &str) -> Result<FilmFormat, String> {
     Ok(match flag {
+        "IX240" => FilmFormat::IX240,
         "135" => FilmFormat::F135,
         "16" => FilmFormat::F16,
         "645" => FilmFormat::F645,
@@ -144,6 +145,7 @@ pub fn parse_format(flag: &str) -> Result<FilmFormat, String> {
 /// What `parse_format` would take for this format, for saying what is on offer
 pub fn format_name(format: &FilmFormat) -> String {
     match format {
+        FilmFormat::IX240 => "24".into(),
         FilmFormat::F135 => "135".into(),
         FilmFormat::F16 => "16".into(),
         FilmFormat::F645 => "645".into(),

--- a/src/bin/nkscan/scan.rs
+++ b/src/bin/nkscan/scan.rs
@@ -109,7 +109,7 @@ pub fn run(args: cli::Scan) -> anyhow::Result<()> {
     // State for the first frame's exposures, reused for the rest so a strip comes out consistent rather than per-frame optimal
     let mut locked: Option<Exposures> = None;
 
-    let uses_adapter = !device.is_mf_scanner()
+    let uses_adapter = !session.capabilities().identity.is_mf_scanner()
         && session
             .capabilities()
             .address

--- a/src/bin/nkscan/scan.rs
+++ b/src/bin/nkscan/scan.rs
@@ -224,8 +224,6 @@ pub fn run(args: cli::Scan) -> anyhow::Result<()> {
                 let x_start = session.capabilities().address.x_axis.address_range.start;
                 let x_boundary = session.capabilities().address.x_axis.boundary;
 
-                dbg!(x_start, x_boundary, length);
-
                 let frames = measured
                     .frames
                     .iter()

--- a/src/bin/nkscan/scan.rs
+++ b/src/bin/nkscan/scan.rs
@@ -196,11 +196,6 @@ pub fn run(args: cli::Scan) -> anyhow::Result<()> {
 
                 // Write the detected frames to the scanner's boundary table
                 let perfs = session.read_perforations().unwrap();
-                let mut file = File::create("perfs.txt")?;
-
-                for perf in &perfs.perfs {
-                    write!(file, "{perf}")?;
-                }
                 let measured = thumbnail::frames_type2(session.capabilities(), &pass, &samples, &perfs, length, None)?;
 
                 session.set_boundaries_type2(&measured)?;

--- a/src/bin/nkscan/scan.rs
+++ b/src/bin/nkscan/scan.rs
@@ -12,6 +12,7 @@ use nkscan::{
     protocol::{
         caps::{film::FilmFormat, set_window::ColorInterleaving, other::HostCooperation},
         decode::Samples,
+        data::FrameTable
     },
     scan::{
         autoexpose::Exposures,
@@ -125,7 +126,7 @@ pub fn run(args: cli::Scan) -> anyhow::Result<()> {
         // Resolve the film format up front where it will be needed, so a
         // missing --format fails before the thumbnail pass
         let film_format = match framing {
-            Framing::Thumbnail => Some(
+            Framing::Thumbnail | Framing::Perforation => Some(
                 resolve_format(
                     format,
                     if !uses_adapter { session.capabilities().address.holder_id } else { session.capabilities().address.connected_adapter },
@@ -134,8 +135,15 @@ pub fn run(args: cli::Scan) -> anyhow::Result<()> {
             _ => None,
         };
 
-        let table = match framing {
-            Framing::Published => framing::table(session.capabilities())?,
+        dbg!(film_format);
+
+        let (table, scan_frames) = match framing {
+            Framing::Published => {
+                let table = framing::table(session.capabilities())?;
+                let frames = table.frames.clone();
+
+                (FrameTable::Boundary(table), frames)
+            }
             Framing::Thumbnail => {
                 let bar = pass_bar("thumbnail");
                 let pass = session.scan_thumbnail_with(&mut samples, |p| bar.report(p))?;
@@ -153,37 +161,67 @@ pub fn run(args: cli::Scan) -> anyhow::Result<()> {
                 let length = film_format.height_dots(optical_dpi);
                 info!(?film_format, length, "frame length");
 
-                let measured =
-                    thumbnail::frames(session.capabilities(), &pass, &samples, length, None)?;
-
                 // Write the detected frames to the scanner's boundary table
+                let measured = thumbnail::frames(session.capabilities(), &pass, &samples, length, None)?;
                 session.set_boundaries(&measured)?;
+
+                let frames = measured.frames.clone();
+
                 info!(frames = measured.frames.len(), "detected frames");
-                measured
+                (FrameTable::Boundary(measured), frames)
             }
             Framing::Caller => {
                 bail!("Caller-supplied frame boundaries are not implemented yet");
             }
             Framing::Perforation => {
-                bail!("Perforation frame discovery is not implemented");
+                let bar = pass_bar("thumbnail");
+                let pass = session.scan_thumbnail_with(&mut samples, |p| bar.report(p))?;
+                bar.finish_and_clear();
+                debug!(
+                    "thumbnail {} x {} in {} channels, complete={}",
+                    pass.cols,
+                    pass.rows,
+                    pass.layout.channels.len(),
+                    pass.complete
+                );
+
+                let film_format = film_format.expect("resolved before the pass");
+                let optical_dpi = session.capabilities().address.y_axis.optical_dpi;
+                let length = film_format.height_dots(optical_dpi);
+                info!(?film_format, length, "frame length");
+
+                // Write the detected frames to the scanner's boundary table
+                let measured = thumbnail::frames_type2(session.capabilities(), &pass, &samples, length, None)?;
+                session.set_boundaries_type2(&measured)?;
+
+                let x_start = session.windows()?[0].origin.0;
+                let x_boundary = session.windows()?[0].origin.0 + session.windows()?[0].size.0;
+                let y_size = session.windows()?[0].origin.1 + session.windows()?[0].size.1;
+
+                let frames = measured
+                    .frames
+                    .iter()
+                    .map(|f| f.rect(x_start, x_boundary, y_size))
+                    .collect();
+                info!(frames = measured.frames.len(), "detected frames");
+                (FrameTable::BoundaryType2(measured), frames)
             }
         };
 
         // Select all or the requested subset of the frames to scan
         let selected_frames = if frames.is_empty() {
-            table.frames
+            scan_frames
         } else {
             frames
                 .iter()
                 .map(|&idx| {
-                    table
-                        .frames
-                        .get(idx - 1) // One-indexed from the user
+                    scan_frames
+                        .get(idx - 1)
                         .cloned()
                         .ok_or(anyhow!(
                             "Requested frame {} not available. Frames detected: {}",
                             idx,
-                            table.frames.len()
+                            scan_frames.len()
                         ))
                 })
                 .collect::<anyhow::Result<Vec<_>>>()?

--- a/src/bin/nkscan/scan.rs
+++ b/src/bin/nkscan/scan.rs
@@ -208,8 +208,9 @@ pub fn run(args: cli::Scan) -> anyhow::Result<()> {
                 let length = film_format.height_dots(optical_dpi);
                 info!(?film_format, length, "frame length");
 
-                // Write the detected frames to the scanner's boundary table
-                let perfs = session.read_perforations().unwrap();
+                // Read perf data and use it to generate Boundary Type2 data for telling the scanner
+                // where the frames reside
+                let perfs = session.read_perforations()?;
                 let measured = thumbnail::frames_type2(
                     session.capabilities(),
                     &pass,

--- a/src/bin/nkscan/scan.rs
+++ b/src/bin/nkscan/scan.rs
@@ -191,15 +191,6 @@ pub fn run(args: cli::Scan) -> anyhow::Result<()> {
                 let length = film_format.height_dots(optical_dpi);
                 info!(?film_format, length, "frame length");
 
-                session.test_unit_ready(Duration::from_secs(5))?;
-
-                session.inquiry_c1(0x04)?;
-                session.inquiry_c1(87)?;
-
-                session.test_unit_ready(Duration::from_secs(5))?;
-
-                session.inquiry_c1(0x04)?;
-
                 // Write the detected frames to the scanner's boundary table
                 let from_scanner = session.read_perforations();
                 dbg!(&from_scanner);
@@ -207,8 +198,7 @@ pub fn run(args: cli::Scan) -> anyhow::Result<()> {
 
                 let measured = thumbnail::frames_type2(session.capabilities(), &pass, &samples, length, None)?;
 
-                session.test_unit_ready(Duration::from_millis(500))?;
-                session.set_boundaries_type2(&measured)?;
+                // session.set_boundaries_type2(&measured)?;
 
                 let x_start = session.windows()?[0].origin.0;
                 let x_boundary = session.windows()?[0].origin.0 + session.windows()?[0].size.0;

--- a/src/bin/nkscan/scan.rs
+++ b/src/bin/nkscan/scan.rs
@@ -10,7 +10,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use nkscan::{
     device,
     protocol::{
-        caps::{film::FilmFormat, set_window::ColorInterleaving},
+        caps::{film::FilmFormat, set_window::ColorInterleaving, other::HostCooperation},
         decode::Samples,
     },
     scan::{
@@ -81,15 +81,19 @@ pub fn run(args: cli::Scan) -> anyhow::Result<()> {
         );
     }
 
+    let mut color_interleave = ColorInterleaving::LINE_WITHOUT_DISTANCE;
+
+    // validate existence of multiline scanning before evaluating superfine; not supported on LS-40/LS-50
+    if !superfine && session.capabilities().features.cooperation.contains(HostCooperation::MULTI_LINE) {
+        color_interleave = ColorInterleaving::MULTILINE_SIMULTANEOUS;
+    }
+
     // What every frame gets scanned with
     // Checked before anything moves
     let recipe = Recipe {
         dpi: dpi.unwrap_or(session.capabilities().address.x_axis.optical_dpi),
         samples,
-        interleaving: match superfine {
-            true => ColorInterleaving::LINE_WITHOUT_DISTANCE,
-            false => ColorInterleaving::MULTILINE_SIMULTANEOUS,
-        },
+        interleaving: color_interleave,
         infrared: ir,
     };
     // Everything the recipe asks for is checked against the pages here, before

--- a/src/bin/nkscan/scan.rs
+++ b/src/bin/nkscan/scan.rs
@@ -102,8 +102,14 @@ pub fn run(args: cli::Scan) -> anyhow::Result<()> {
     // State for the first frame's exposures, reused for the rest so a strip comes out consistent rather than per-frame optimal
     let mut locked: Option<Exposures> = None;
 
+
+    let uses_adapter = !device.is_mf_scanner() && session.capabilities().address.adapter_id.is_some_and(|id| id > 0);
+
     // Nothing can be framed before something is loaded
-    wait_for_film(&mut session, "Load a film holder")?;
+    wait_for_film(
+        &mut session,
+        &format!("Load a film {}", if uses_adapter { "strip" } else { "holder" }),
+    )?;
 
     // One buffer for every strip
     let mut samples = Samples::default();
@@ -119,10 +125,12 @@ pub fn run(args: cli::Scan) -> anyhow::Result<()> {
         // Resolve the film format up front where it will be needed, so a
         // missing --format fails before the thumbnail pass
         let film_format = match framing {
-            Framing::Thumbnail => Some(resolve_format(
-                format,
-                session.capabilities().address.holder_id,
-            )?),
+            Framing::Thumbnail => Some(
+                resolve_format(
+                    format,
+                    if !uses_adapter { session.capabilities().address.holder_id } else { session.capabilities().address.connected_adapter },
+                )?,
+            ),
             _ => None,
         };
 
@@ -345,8 +353,13 @@ fn resolve_format(flag: Option<FilmFormat>, holder_id: Option<u8>) -> anyhow::Re
     if let Some(format) = flag {
         return Ok(format);
     }
+
+    dbg!(holder_id);
     let id = holder_id.ok_or_else(|| anyhow!("No holder loaded; supply --format"))?;
-    FilmFormat::from_holder(id).ok_or_else(|| {
+
+    FilmFormat::from_holder(id)
+    .or_else(|| FilmFormat::from_adapter(id))
+    .ok_or_else(|| {
         let choices = FilmFormat::choices_for_holder(id)
             .map(|c| {
                 format!(
@@ -358,6 +371,9 @@ fn resolve_format(flag: Option<FilmFormat>, holder_id: Option<u8>) -> anyhow::Re
                 )
             })
             .unwrap_or_default();
-        anyhow!("This holder does not fix the film format; supply --format{choices}")
+
+        anyhow!(
+            "This holder does not fix the film format; supply --format{choices}"
+        )
     })
 }

--- a/src/bin/nkscan/scan.rs
+++ b/src/bin/nkscan/scan.rs
@@ -24,7 +24,7 @@ use nkscan::{
     },
     session::Session,
 };
-use std::{borrow::Cow, time::Duration};
+use std::{borrow::Cow, time::Duration, fs::File, io::Write};
 use tracing::*;
 
 /// Long enough for a full resolution pass over the largest frame
@@ -174,6 +174,9 @@ pub fn run(args: cli::Scan) -> anyhow::Result<()> {
             Framing::Perforation => {
                 let perfs = session.read_perforations()?;
                 let frames = session.read_boundaries_type2();
+
+                dbg!(perfs);
+                dbg!(frames);
                 let bar = pass_bar("thumbnail");
 
                 let pass = session.scan_thumbnail_with(&mut samples, |p| bar.report(p))?;
@@ -192,13 +195,15 @@ pub fn run(args: cli::Scan) -> anyhow::Result<()> {
                 info!(?film_format, length, "frame length");
 
                 // Write the detected frames to the scanner's boundary table
-                let from_scanner = session.read_perforations();
-                dbg!(&from_scanner);
-                from_scanner?;
+                let perfs = session.read_perforations().unwrap();
+                let mut file = File::create("perfs.txt")?;
 
-                let measured = thumbnail::frames_type2(session.capabilities(), &pass, &samples, length, None)?;
+                for perf in &perfs.perfs {
+                    write!(file, "{perf}")?;
+                }
+                let measured = thumbnail::frames_type2(session.capabilities(), &pass, &samples, &perfs, length, None)?;
 
-                // session.set_boundaries_type2(&measured)?;
+                session.set_boundaries_type2(&measured)?;
 
                 let x_start = session.windows()?[0].origin.0;
                 let x_boundary = session.windows()?[0].origin.0 + session.windows()?[0].size.0;

--- a/src/bin/nkscan/scan.rs
+++ b/src/bin/nkscan/scan.rs
@@ -24,7 +24,7 @@ use nkscan::{
     },
     session::Session,
 };
-use std::{borrow::Cow, fs::File, io::Write, time::Duration};
+use std::{borrow::Cow, time::Duration};
 use tracing::*;
 
 /// Long enough for a full resolution pass over the largest frame
@@ -221,14 +221,15 @@ pub fn run(args: cli::Scan) -> anyhow::Result<()> {
 
                 session.set_boundaries_type2(&measured)?;
 
-                let x_start = session.windows()?[0].origin.0;
-                let x_boundary = session.windows()?[0].origin.0 + session.windows()?[0].size.0;
-                let y_size = session.windows()?[0].origin.1 + session.windows()?[0].size.1;
+                let x_start = session.capabilities().address.x_axis.address_range.start;
+                let x_boundary = session.capabilities().address.x_axis.boundary;
+
+                dbg!(x_start, x_boundary, length);
 
                 let frames = measured
                     .frames
                     .iter()
-                    .map(|f| f.rect(x_start, x_boundary, y_size))
+                    .map(|f| f.rect(x_start, x_boundary, length))
                     .collect();
                 info!(frames = measured.frames.len(), "detected frames");
                 (FrameTable::BoundaryType2(measured), frames)

--- a/src/bin/nkscan/scan.rs
+++ b/src/bin/nkscan/scan.rs
@@ -150,7 +150,7 @@ pub fn run(args: cli::Scan) -> anyhow::Result<()> {
             _ => None,
         };
 
-        let (table, scan_frames) = match framing {
+        let (_table, scan_frames) = match framing {
             Framing::Published => {
                 let table = framing::table(session.capabilities())?;
                 let frames = table.frames.clone();

--- a/src/bin/nkscan/scan.rs
+++ b/src/bin/nkscan/scan.rs
@@ -24,7 +24,7 @@ use nkscan::{
     },
     session::Session,
 };
-use std::{borrow::Cow, time::Duration, fs::File, io::Write};
+use std::{borrow::Cow, fs::File, io::Write, time::Duration};
 use tracing::*;
 
 /// Long enough for a full resolution pass over the largest frame
@@ -85,7 +85,13 @@ pub fn run(args: cli::Scan) -> anyhow::Result<()> {
     let mut color_interleave = ColorInterleaving::LINE_WITHOUT_DISTANCE;
 
     // validate existence of multiline scanning before evaluating superfine; not supported on LS-40/LS-50
-    if !superfine && session.capabilities().features.cooperation.contains(HostCooperation::MULTI_LINE) {
+    if !superfine
+        && session
+            .capabilities()
+            .features
+            .cooperation
+            .contains(HostCooperation::MULTI_LINE)
+    {
         color_interleave = ColorInterleaving::MULTILINE_SIMULTANEOUS;
     }
 
@@ -103,13 +109,20 @@ pub fn run(args: cli::Scan) -> anyhow::Result<()> {
     // State for the first frame's exposures, reused for the rest so a strip comes out consistent rather than per-frame optimal
     let mut locked: Option<Exposures> = None;
 
-
-    let uses_adapter = !device.is_mf_scanner() && session.capabilities().address.adapter_id.is_some_and(|id| id > 0);
+    let uses_adapter = !device.is_mf_scanner()
+        && session
+            .capabilities()
+            .address
+            .adapter_id
+            .is_some_and(|id| id > 0);
 
     // Nothing can be framed before something is loaded
     wait_for_film(
         &mut session,
-        &format!("Load a film {}", if uses_adapter { "strip" } else { "holder" }),
+        &format!(
+            "Load a film {}",
+            if uses_adapter { "strip" } else { "holder" }
+        ),
     )?;
 
     // One buffer for every strip
@@ -126,12 +139,14 @@ pub fn run(args: cli::Scan) -> anyhow::Result<()> {
         // Resolve the film format up front where it will be needed, so a
         // missing --format fails before the thumbnail pass
         let film_format = match framing {
-            Framing::Thumbnail | Framing::Perforation => Some(
-                resolve_format(
-                    format,
-                    if !uses_adapter { session.capabilities().address.holder_id } else { session.capabilities().address.connected_adapter },
-                )?,
-            ),
+            Framing::Thumbnail | Framing::Perforation => Some(resolve_format(
+                format,
+                if !uses_adapter {
+                    session.capabilities().address.holder_id
+                } else {
+                    session.capabilities().address.connected_adapter
+                },
+            )?),
             _ => None,
         };
 
@@ -160,7 +175,8 @@ pub fn run(args: cli::Scan) -> anyhow::Result<()> {
                 info!(?film_format, length, "frame length");
 
                 // Write the detected frames to the scanner's boundary table
-                let measured = thumbnail::frames(session.capabilities(), &pass, &samples, length, None)?;
+                let measured =
+                    thumbnail::frames(session.capabilities(), &pass, &samples, length, None)?;
                 session.set_boundaries(&measured)?;
 
                 let frames = measured.frames.clone();
@@ -172,11 +188,9 @@ pub fn run(args: cli::Scan) -> anyhow::Result<()> {
                 bail!("Caller-supplied frame boundaries are not implemented yet");
             }
             Framing::Perforation => {
-                let perfs = session.read_perforations()?;
-                let frames = session.read_boundaries_type2();
-
-                dbg!(perfs);
-                dbg!(frames);
+                // discard old data
+                let _ = session.read_perforations()?;
+                let _ = session.read_boundaries_type2();
                 let bar = pass_bar("thumbnail");
 
                 let pass = session.scan_thumbnail_with(&mut samples, |p| bar.report(p))?;
@@ -196,7 +210,14 @@ pub fn run(args: cli::Scan) -> anyhow::Result<()> {
 
                 // Write the detected frames to the scanner's boundary table
                 let perfs = session.read_perforations().unwrap();
-                let measured = thumbnail::frames_type2(session.capabilities(), &pass, &samples, &perfs, length, None)?;
+                let measured = thumbnail::frames_type2(
+                    session.capabilities(),
+                    &pass,
+                    &samples,
+                    &perfs,
+                    length,
+                    None,
+                )?;
 
                 session.set_boundaries_type2(&measured)?;
 
@@ -221,14 +242,11 @@ pub fn run(args: cli::Scan) -> anyhow::Result<()> {
             frames
                 .iter()
                 .map(|&idx| {
-                    scan_frames
-                        .get(idx - 1)
-                        .cloned()
-                        .ok_or(anyhow!(
-                            "Requested frame {} not available. Frames detected: {}",
-                            idx,
-                            scan_frames.len()
-                        ))
+                    scan_frames.get(idx - 1).cloned().ok_or(anyhow!(
+                        "Requested frame {} not available. Frames detected: {}",
+                        idx,
+                        scan_frames.len()
+                    ))
                 })
                 .collect::<anyhow::Result<Vec<_>>>()?
         };
@@ -401,22 +419,20 @@ fn resolve_format(flag: Option<FilmFormat>, holder_id: Option<u8>) -> anyhow::Re
     let id = holder_id.ok_or_else(|| anyhow!("No holder loaded; supply --format"))?;
 
     FilmFormat::from_holder(id)
-    .or_else(|| FilmFormat::from_adapter(id))
-    .ok_or_else(|| {
-        let choices = FilmFormat::choices_for_holder(id)
-            .map(|c| {
-                format!(
-                    " (try: {})",
-                    c.iter()
-                        .map(cli::format_name)
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                )
-            })
-            .unwrap_or_default();
+        .or_else(|| FilmFormat::from_adapter(id))
+        .ok_or_else(|| {
+            let choices = FilmFormat::choices_for_holder(id)
+                .map(|c| {
+                    format!(
+                        " (try: {})",
+                        c.iter()
+                            .map(cli::format_name)
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    )
+                })
+                .unwrap_or_default();
 
-        anyhow!(
-            "This holder does not fix the film format; supply --format{choices}"
-        )
-    })
+            anyhow!("This holder does not fix the film format; supply --format{choices}")
+        })
 }

--- a/src/bin/nkscan/scan.rs
+++ b/src/bin/nkscan/scan.rs
@@ -172,8 +172,8 @@ pub fn run(args: cli::Scan) -> anyhow::Result<()> {
                 bail!("Caller-supplied frame boundaries are not implemented yet");
             }
             Framing::Perforation => {
-                let _ = session.read_perforations()?;
-                let _ = session.read_boundaries_type2()?;
+                let perfs = session.read_perforations()?;
+                let frames = session.read_boundaries_type2();
                 let bar = pass_bar("thumbnail");
 
                 let pass = session.scan_thumbnail_with(&mut samples, |p| bar.report(p))?;
@@ -191,15 +191,21 @@ pub fn run(args: cli::Scan) -> anyhow::Result<()> {
                 let length = film_format.height_dots(optical_dpi);
                 info!(?film_format, length, "frame length");
 
+                session.test_unit_ready(Duration::from_secs(5))?;
+
+                session.inquiry_c1(0x04)?;
+                session.inquiry_c1(87)?;
+
+                session.test_unit_ready(Duration::from_secs(5))?;
+
+                session.inquiry_c1(0x04)?;
+
                 // Write the detected frames to the scanner's boundary table
-                let measured = thumbnail::frames_type2(session.capabilities(), &pass, &samples, length, None)?;
-
-                session.test_unit_ready(Duration::from_millis(500))?;
-                session.test_unit_ready(Duration::from_millis(500))?;
-
                 let from_scanner = session.read_perforations();
                 dbg!(&from_scanner);
                 from_scanner?;
+
+                let measured = thumbnail::frames_type2(session.capabilities(), &pass, &samples, length, None)?;
 
                 session.test_unit_ready(Duration::from_millis(500))?;
                 session.set_boundaries_type2(&measured)?;

--- a/src/bin/nkscan/scan.rs
+++ b/src/bin/nkscan/scan.rs
@@ -10,9 +10,9 @@ use indicatif::{ProgressBar, ProgressStyle};
 use nkscan::{
     device,
     protocol::{
-        caps::{film::FilmFormat, set_window::ColorInterleaving, other::HostCooperation},
+        caps::{film::FilmFormat, other::HostCooperation, set_window::ColorInterleaving},
+        data::FrameTable,
         decode::Samples,
-        data::FrameTable
     },
     scan::{
         autoexpose::Exposures,

--- a/src/bin/nkscan/scan.rs
+++ b/src/bin/nkscan/scan.rs
@@ -135,8 +135,6 @@ pub fn run(args: cli::Scan) -> anyhow::Result<()> {
             _ => None,
         };
 
-        dbg!(film_format);
-
         let (table, scan_frames) = match framing {
             Framing::Published => {
                 let table = framing::table(session.capabilities())?;
@@ -174,7 +172,10 @@ pub fn run(args: cli::Scan) -> anyhow::Result<()> {
                 bail!("Caller-supplied frame boundaries are not implemented yet");
             }
             Framing::Perforation => {
+                let _ = session.read_perforations()?;
+                let _ = session.read_boundaries_type2()?;
                 let bar = pass_bar("thumbnail");
+
                 let pass = session.scan_thumbnail_with(&mut samples, |p| bar.report(p))?;
                 bar.finish_and_clear();
                 debug!(
@@ -192,6 +193,15 @@ pub fn run(args: cli::Scan) -> anyhow::Result<()> {
 
                 // Write the detected frames to the scanner's boundary table
                 let measured = thumbnail::frames_type2(session.capabilities(), &pass, &samples, length, None)?;
+
+                session.test_unit_ready(Duration::from_millis(500))?;
+                session.test_unit_ready(Duration::from_millis(500))?;
+
+                let from_scanner = session.read_perforations();
+                dbg!(&from_scanner);
+                from_scanner?;
+
+                session.test_unit_ready(Duration::from_millis(500))?;
                 session.set_boundaries_type2(&measured)?;
 
                 let x_start = session.windows()?[0].origin.0;
@@ -392,7 +402,6 @@ fn resolve_format(flag: Option<FilmFormat>, holder_id: Option<u8>) -> anyhow::Re
         return Ok(format);
     }
 
-    dbg!(holder_id);
     let id = holder_id.ok_or_else(|| anyhow!("No holder loaded; supply --format"))?;
 
     FilmFormat::from_holder(id)

--- a/src/device.rs
+++ b/src/device.rs
@@ -94,10 +94,7 @@ impl Device {
     }
 
     pub fn is_mf_scanner(&self) -> bool {
-        match self.model {
-            Some(Model::Ls8000 | Model::Ls9000) => true,
-            _ => false
-        }
+        matches!(self.model, Some(Model::Ls8000 | Model::Ls9000))
     }
 }
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -92,10 +92,6 @@ impl Device {
             )),
         }
     }
-
-    pub fn is_mf_scanner(&self) -> bool {
-        matches!(self.model, Some(Model::Ls8000 | Model::Ls9000))
-    }
 }
 
 impl fmt::Display for Device {

--- a/src/device.rs
+++ b/src/device.rs
@@ -92,6 +92,13 @@ impl Device {
             )),
         }
     }
+
+    pub fn is_mf_scanner(&self) -> bool {
+        match self.model {
+            Some(Model::Ls8000 | Model::Ls9000) => true,
+            _ => false
+        }
+    }
 }
 
 impl fmt::Display for Device {

--- a/src/protocol/caps/address.rs
+++ b/src/protocol/caps/address.rs
@@ -351,10 +351,6 @@ mod tests {
         assert_eq!(five.pitch_rule, PitchRule::OnePlusEven);
         assert_eq!((nine.lines, five.lines), (3, 2));
 
-        // The LS-5000 cannot crop in X, so a caller must take the full boundary
-        assert!(nine.x_axis.croppable());
-        assert!(!five.x_axis.croppable());
-
         // Only the LS-9000 publishes frame rectangles
         assert!(nine.coordinate_base.contains(CoordinateBase::FRAME_RECTS));
         assert!(!five.coordinate_base.contains(CoordinateBase::FRAME_RECTS));

--- a/src/protocol/caps/address.rs
+++ b/src/protocol/caps/address.rs
@@ -89,7 +89,7 @@ pub struct Axis {
 impl Axis {
     /// Equal ends mean no arbitrary range on this axis: the caller has to use the full [`boundary`](Self::boundary) width
     pub fn croppable(&self) -> bool {
-        self.address_range.start != self.address_range.last
+        (self.address_range.last == 0) || (self.address_range.start != self.address_range.last)
     }
 }
 

--- a/src/protocol/caps/address.rs
+++ b/src/protocol/caps/address.rs
@@ -22,14 +22,17 @@ pub struct Address {
     /// Number of units that can be attached simultaneously. Byte 13
     pub units_attachable: u8,
     /// ID of the attached adapter. None when none is attached, or one the unit does not recognize. Byte 14
+    /// On LS-4x/LS-5x this field is used differently: it reads 1 when an adapter is inserted, or 0 when it's empty.
     pub adapter_id: Option<u8>,
     /// ID of the attached holder, same convention. Byte 15
     pub holder_id: Option<u8>,
+    /// On LS-4x/LS-5x: connected adapter ID, byte 17.
+    pub connected_adapter: Option<u8>,
     /// Coordinate base information. Byte 16 bits 2-7
     pub coordinate_base: CoordinateBase,
     /// Pitch rule. Byte 16 bits 0-1, with the line gap from byte 85 folded in
     pub pitch_rule: PitchRule,
-    /// The kind of addressing that is supported. Byte 17
+    /// The kind of addressing that is supported. Byte 17. Different use on LS-4x/LS-5x, see connected_adapter
     pub addressing_kind: AddressingKind,
     /// Details of the X-axis. Bytes 18-39
     pub x_axis: Axis,
@@ -204,6 +207,7 @@ impl TryFrom<&Page> for Address {
         let (base, len) = page.flags(head + 11)?; // byte 16
         let rest = head + 11 + len; // byte 17
         let addressing_kind = AddressingKind::from_bits_truncate(page.u8(rest)?);
+        let connected_adapter = page.opt_u8(rest)?; // TODO: find a better way to store this
 
         // Both axes are the same 22 byte block, X then Y
         let axis = |at: usize| -> Result<Axis, Error> {
@@ -264,6 +268,7 @@ impl TryFrom<&Page> for Address {
             units_attachable,
             adapter_id,
             holder_id,
+            connected_adapter,
             coordinate_base,
             pitch_rule,
             addressing_kind,

--- a/src/protocol/caps/film.rs
+++ b/src/protocol/caps/film.rs
@@ -61,12 +61,12 @@ impl FilmFormat {
     /// selects the format via its mask
     pub fn from_holder(holder_id: u8) -> Option<Self> {
         match holder_id {
-            0x12 => Some(Self::F16),   // FH-816
-            0x19 => Some(Self::F645),  // FH-869GR 6×4.5
-            0x1A => Some(Self::F66),   // FH-869GR 6×6
-            0x1B => Some(Self::F67),   // FH-869GR 6×7
-            0x1C => Some(Self::F68),   // FH-869GR 6×8
-            0x1D => Some(Self::F69),   // FH-869GR 6×9
+            0x12 => Some(Self::F16),  // FH-816
+            0x19 => Some(Self::F645), // FH-869GR 6×4.5
+            0x1A => Some(Self::F66),  // FH-869GR 6×6
+            0x1B => Some(Self::F67),  // FH-869GR 6×7
+            0x1C => Some(Self::F68),  // FH-869GR 6×8
+            0x1D => Some(Self::F69),  // FH-869GR 6×9
             _ => None,
         }
     }

--- a/src/protocol/caps/film.rs
+++ b/src/protocol/caps/film.rs
@@ -11,6 +11,8 @@
 /// A film format, keyed by its frame height in millimetres
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FilmFormat {
+    // APS
+    IX240,
     /// 135 film (35mm), 24 × 36 mm
     F135,
     /// 16mm film, 16 × 20 mm (FH-816)
@@ -33,6 +35,7 @@ impl FilmFormat {
     /// Frame height along the feed, in mm
     pub const fn height_mm(self) -> u32 {
         match self {
+            Self::IX240 => 24,
             Self::F135 => 36,
             Self::F16 => 20,
             Self::F645 => 45,
@@ -58,12 +61,12 @@ impl FilmFormat {
     /// selects the format via its mask
     pub fn from_holder(holder_id: u8) -> Option<Self> {
         match holder_id {
-            0x12 => Some(Self::F16),  // FH-816
-            0x19 => Some(Self::F645), // FH-869GR 6×4.5
-            0x1A => Some(Self::F66),  // FH-869GR 6×6
-            0x1B => Some(Self::F67),  // FH-869GR 6×7
-            0x1C => Some(Self::F68),  // FH-869GR 6×8
-            0x1D => Some(Self::F69),  // FH-869GR 6×9
+            0x12 => Some(Self::F16),   // FH-816
+            0x19 => Some(Self::F645),  // FH-869GR 6×4.5
+            0x1A => Some(Self::F66),   // FH-869GR 6×6
+            0x1B => Some(Self::F67),   // FH-869GR 6×7
+            0x1C => Some(Self::F68),   // FH-869GR 6×8
+            0x1D => Some(Self::F69),   // FH-869GR 6×9
             _ => None,
         }
     }
@@ -79,6 +82,16 @@ impl FilmFormat {
             0x16 => Some(&[Self::F66, Self::F67, Self::F69]), // FH-869M
             0x17 => Some(&[Self::F66, Self::F67, Self::F69]), // FH-869S
             0x18 => Some(&[Self::F66, Self::F67, Self::F69]), // FH-869G
+            _ => None,
+        }
+    }
+
+    /// Same as holder ID, but for LS-4x and LS-5x adapters
+    pub fn from_adapter(adapter_id: u8) -> Option<Self> {
+        match adapter_id {
+            0x31 => Some(Self::F135),  // SA-21/SA-30
+            0x35 => Some(Self::IX240), // IA-20
+            0x32 => Some(Self::F135),  // SF-210
             _ => None,
         }
     }

--- a/src/protocol/caps/identity.rs
+++ b/src/protocol/caps/identity.rs
@@ -36,11 +36,6 @@ impl Identity {
         Model::from_product(&self.product)
     }
 
-    pub fn is_mf(&self) -> bool {
-        let model = Model::from_product(&self.product).unwrap();
-        model == Model::Ls8000 || model == Model::Ls9000
-    }
-
     pub fn parse(bytes: &[u8]) -> Result<Self, Error> {
         if bytes.len() < Self::LENGTH {
             return Err(Error::Truncated {

--- a/src/protocol/caps/identity.rs
+++ b/src/protocol/caps/identity.rs
@@ -36,6 +36,16 @@ impl Identity {
         Model::from_product(&self.product)
     }
 
+    pub fn is_mf(&self) -> bool {
+        let model = Model::from_product(&self.product).unwrap();
+
+        if model == Model::Ls8000 || model == Model::Ls9000 {
+            true
+        } else {
+            false
+        }
+    }
+
     pub fn parse(bytes: &[u8]) -> Result<Self, Error> {
         if bytes.len() < Self::LENGTH {
             return Err(Error::Truncated {

--- a/src/protocol/caps/identity.rs
+++ b/src/protocol/caps/identity.rs
@@ -37,7 +37,10 @@ impl Identity {
     }
 
     pub fn is_mf_scanner(&self) -> bool {
-        matches!(Model::from_product(&self.product).unwrap().into(), Some(Model::Ls8000 | Model::Ls9000))
+        matches!(
+            Model::from_product(&self.product).unwrap().into(),
+            Some(Model::Ls8000 | Model::Ls9000)
+        )
     }
 
     pub fn parse(bytes: &[u8]) -> Result<Self, Error> {
@@ -64,7 +67,6 @@ impl Identity {
     pub fn is_scanner(&self) -> bool {
         self.qualifier == 0 && self.device_type == SCANNER
     }
-
 }
 
 /// The identification fields are space-padded ASCII

--- a/src/protocol/caps/identity.rs
+++ b/src/protocol/caps/identity.rs
@@ -38,12 +38,7 @@ impl Identity {
 
     pub fn is_mf(&self) -> bool {
         let model = Model::from_product(&self.product).unwrap();
-
-        if model == Model::Ls8000 || model == Model::Ls9000 {
-            true
-        } else {
-            false
-        }
+        model == Model::Ls8000 || model == Model::Ls9000
     }
 
     pub fn parse(bytes: &[u8]) -> Result<Self, Error> {

--- a/src/protocol/caps/identity.rs
+++ b/src/protocol/caps/identity.rs
@@ -36,6 +36,10 @@ impl Identity {
         Model::from_product(&self.product)
     }
 
+    pub fn is_mf_scanner(&self) -> bool {
+        matches!(Model::from_product(&self.product).unwrap().into(), Some(Model::Ls8000 | Model::Ls9000))
+    }
+
     pub fn parse(bytes: &[u8]) -> Result<Self, Error> {
         if bytes.len() < Self::LENGTH {
             return Err(Error::Truncated {
@@ -60,6 +64,7 @@ impl Identity {
     pub fn is_scanner(&self) -> bool {
         self.qualifier == 0 && self.device_type == SCANNER
     }
+
 }
 
 /// The identification fields are space-padded ASCII

--- a/src/protocol/data.rs
+++ b/src/protocol/data.rs
@@ -219,6 +219,7 @@ impl DataType {
 
     pub fn qualifier(self) -> Option<(u8, u8)> {
         match self {
+            Self::Perforation => Some((0, 0x00)),
             Self::Boundary2 => Some((0, 0x3B)),
             _ => self.row().width.map(|width| {
                 (

--- a/src/protocol/data.rs
+++ b/src/protocol/data.rs
@@ -1,5 +1,7 @@
 //! READ and SEND data types. Section 2-11
 
+use std::fmt;
+
 use super::{caps::other::DataTypes, sense::Coop};
 use crate::error::Error;
 use bitflags::bitflags;
@@ -220,7 +222,7 @@ impl DataType {
     pub fn qualifier(self) -> Option<(u8, u8)> {
         match self {
             Self::Perforation => Some((0, 0x00)),
-            Self::Boundary2 => Some((0, 0x3B)),
+            Self::Boundary2 => Some((0, 0x03)),
             _ => self.row().width.map(|width| {
                 (
                     width,
@@ -313,7 +315,7 @@ pub struct FramePosition {
     /// Byte 10, perforation decimal
     pub perf_decimal: u8,
     /// Byte 11, pulse number
-    pub pulse: u8,
+    pub pulse_number: u8,
 }
 
 impl FramePosition {
@@ -323,6 +325,15 @@ impl FramePosition {
             left: x_start,
             bottom: self.top + length - 1,
             right: x_start + x_boundary - 1,
+        }
+    }
+
+    pub fn new(dpi_device: u16, dpi_thumb: u16, y_start: u32, perf_info: PerforationInformation) -> Self {
+        return FramePosition {
+            top: (y_start as f32 * (dpi_device as f32 / dpi_thumb as f32).round()).floor() as u32,
+            perf_number: perf_info.perf_number,
+            perf_decimal: perf_info.num_pattern,
+            pulse_number: perf_info.pulse_number
         }
     }
 }
@@ -410,6 +421,89 @@ impl Boundary {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PerforationInformation {
+    /// Bytes 4-5: start perf number for this line
+    pub perf_number: u16,
+    /// Byte 6: switching flag + number of patterns for this line
+    pub count_switching_flag: bool,
+    pub num_pattern: u8,
+    /// Byte 7: pulse number for this line
+    pub pulse_number: u8
+}
+
+/// Perforation info from 8Eh, 2-11-8 (LS-5000)
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PerfInformation {
+    pub perfs: Vec<PerforationInformation>
+}
+
+impl PerfInformation {
+    /// Bytes before the first frame.
+    const HEAD: usize = 4;
+
+    /// Bytes occupied by perforation records
+    const PERFS: usize = 4;
+
+    pub fn from_bytes(b: &[u8]) -> Option<Self> {
+        let head: &[u8; Self::HEAD] = b.get(..Self::HEAD)?.try_into().ok()?;
+
+        let parameter_length =
+            ((head[0] as usize) << 16) |
+            ((head[1] as usize) << 8) |
+            (head[2] as usize);
+
+        let bytes_per_parameter = usize::from(head[3]);
+
+        if bytes_per_parameter != Self::PERFS {
+            return None;
+        }
+
+        let total = parameter_length.checked_add(3)?;
+
+        if total < Self::HEAD || b.len() < total {
+            return None;
+        }
+
+        let payload_len = total - Self::HEAD;
+
+        if payload_len % Self::PERFS != 0 {
+            return None;
+        }
+
+        let num_records = payload_len / Self::PERFS;
+
+        let mut perfs = Vec::with_capacity(num_records);
+
+        for n in 0..num_records {
+            let at = Self::HEAD + n * Self::PERFS;
+            let r = b.get(at..at + Self::PERFS)?;
+
+            perfs.push(PerforationInformation {
+                perf_number: u16::from_be_bytes([r[0], r[1]]),
+                count_switching_flag: r[2] & 0x80 != 0,
+                num_pattern: r[2] & 0x7f,
+                pulse_number: r[3],
+            });
+        }
+
+        Some(Self { perfs })
+    }
+}
+
+impl fmt::Display for PerforationInformation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(
+            f,
+            "perf_number={} count_switching_flag={} num_pattern={} pulse_number={}",
+            self.perf_number,
+            self.count_switching_flag,
+            self.num_pattern,
+            self.pulse_number,
+        )
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct BoundaryType2 {
     pub frames: Vec<FramePosition>,
 }
@@ -418,8 +512,8 @@ impl BoundaryType2 {
     /// Bytes before the first frame.
     const HEAD: usize = 4;
 
-    /// Bytes occupied by each frame record.
-    const FRAME: usize = 8;
+    /// Bytes occupied by each boundary record.
+    const BOUNDARY: usize = 8;
 
     pub fn from_bytes(b: &[u8]) -> Option<Self> {
         let head: &[u8; Self::HEAD] = b.get(..Self::HEAD)?.try_into().ok()?;
@@ -435,7 +529,7 @@ impl BoundaryType2 {
         let total = parameter_length.checked_add(1)?;
 
         // The reserved byte is currently ignored.
-        let expected = Self::HEAD.checked_add(count.checked_mul(Self::FRAME)?)?;
+        let expected = Self::HEAD.checked_add(count.checked_mul(Self::BOUNDARY)?)?;
 
         // Reject truncated or structurally inconsistent data.
         if total != expected || b.len() < total {
@@ -445,14 +539,14 @@ impl BoundaryType2 {
         let mut frames = Vec::with_capacity(count);
 
         for n in 0..count {
-            let at = Self::HEAD + n * Self::FRAME;
-            let r = b.get(at..at + Self::FRAME)?;
+            let at = Self::HEAD + n * Self::BOUNDARY;
+            let r = b.get(at..at + Self::BOUNDARY)?;
 
             frames.push(FramePosition {
                 top: u32::from_be_bytes([r[0], r[1], r[2], r[3]]),
                 perf_number: u16::from_be_bytes([r[4], r[5]]),
                 perf_decimal: r[6],
-                pulse: r[7],
+                pulse_number: r[7],
             });
         }
 
@@ -471,7 +565,7 @@ impl BoundaryType2 {
         }
 
         let total = Self::HEAD
-            .checked_add(self.frames.len() * Self::FRAME)
+            .checked_add(self.frames.len() * Self::BOUNDARY)
             .ok_or_else(|| Error::Unsupported {
                 op: "boundary_type2",
                 reason: "boundary information is too large".into(),
@@ -497,7 +591,7 @@ impl BoundaryType2 {
             out.extend_from_slice(&frame.top.to_be_bytes());
             out.extend_from_slice(&frame.perf_number.to_be_bytes());
             out.push(frame.perf_decimal);
-            out.push(frame.pulse);
+            out.push(frame.pulse_number);
         }
 
         Ok(out)

--- a/src/protocol/data.rs
+++ b/src/protocol/data.rs
@@ -309,6 +309,7 @@ pub struct Rect {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct FramePosition {
     /// Bytes 4-7, Y address for line 1
+    /// address = 7 × (108 * perf_number + 22 * perf_decimal + pulse_number
     pub top: u32,
     /// Bytes 8-9, perforation number
     pub perf_number: u16,
@@ -328,13 +329,25 @@ impl FramePosition {
         }
     }
 
-    pub fn new(dpi_device: u16, dpi_thumb: u16, y_start: u32, perf_info: PerforationInformation) -> Self {
-        return FramePosition {
-            top: (y_start as f32 * (dpi_device as f32 / dpi_thumb as f32).round()).floor() as u32,
-            perf_number: perf_info.perf_number,
-            perf_decimal: perf_info.num_pattern,
-            pulse_number: perf_info.pulse_number
-        }
+    /// construct a FramePosition entry from detected y_start, as pixel location on the thumb strip
+    /// all other values are inferred using data read from 8Eh PerforationInformation
+    pub fn new(
+        dpi_device: u16,
+        dpi_thumb: u16,
+        y_start: u32,
+        perf_info: &PerfInformation,
+    ) -> Option<Self> {
+
+        // use approximation to find the closest perf match, then use that to calculate the address
+        let approx_addr = (y_start as f32 * dpi_device as f32 / dpi_thumb as f32).round() as u32;
+        let perf = perf_info.nearest(approx_addr)?;
+
+        Some(FramePosition {
+            top: PerfInformation::address(perf),
+            perf_number: perf.perf_number,
+            perf_decimal: perf.perf_decimal,
+            pulse_number: perf.pulse_number,
+        })
     }
 }
 
@@ -422,12 +435,13 @@ impl Boundary {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct PerforationInformation {
-    /// Bytes 4-5: start perf number for this line
+    /// Bytes 4-5: perforation number
     pub perf_number: u16,
-    /// Byte 6: switching flag + number of patterns for this line
+    /// Byte 6 bit 7: switching flag
     pub count_switching_flag: bool,
-    pub num_pattern: u8,
-    /// Byte 7: pulse number for this line
+    /// Byte 6 bit 6-0: perforation decimal
+    pub perf_decimal: u8, 
+    /// Byte 7: raw encoder pulses accumulated in current phase
     pub pulse_number: u8
 }
 
@@ -481,23 +495,35 @@ impl PerfInformation {
             perfs.push(PerforationInformation {
                 perf_number: u16::from_be_bytes([r[0], r[1]]),
                 count_switching_flag: r[2] & 0x80 != 0,
-                num_pattern: r[2] & 0x7f,
+                perf_decimal: r[2] & 0x7f,
                 pulse_number: r[3],
             });
         }
 
         Some(Self { perfs })
     }
+
+    /// encoder-space address for a given perforation reading
+    fn address(perf: &PerforationInformation) -> u32 {
+        7 * (108 * perf.perf_number as u32
+            + 22 * perf.perf_decimal as u32
+            + perf.pulse_number as u32)
+    }
+
+    pub fn nearest(&self, addr: u32) -> Option<&PerforationInformation> {
+        self.perfs.iter().min_by_key(|p| Self::address(p).abs_diff(addr))
+    }
 }
 
 impl fmt::Display for PerforationInformation {
+    // perf_number,num_pattern,count_switching_flag,pulse_number
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(
             f,
-            "perf_number={} count_switching_flag={} num_pattern={} pulse_number={}",
+            "{},{},{},{}",
             self.perf_number,
+            self.perf_decimal,
             self.count_switching_flag,
-            self.num_pattern,
             self.pulse_number,
         )
     }
@@ -571,8 +597,7 @@ impl BoundaryType2 {
                 reason: "boundary information is too large".into(),
             })?;
 
-        // Parameter length is n - 1, where n is the total parameter size.
-        let parameter_length = total - 1;
+        let parameter_length = total - 2;
 
         if parameter_length > u16::MAX as usize {
             return Err(Error::Unsupported {

--- a/src/protocol/data.rs
+++ b/src/protocol/data.rs
@@ -337,7 +337,6 @@ impl FramePosition {
         y_start: u32,
         perf_info: &PerfInformation,
     ) -> Option<Self> {
-
         // use approximation to find the closest perf match, then use that to calculate the address
         let approx_addr = (y_start as f32 * dpi_device as f32 / dpi_thumb as f32).round() as u32;
         let perf = perf_info.nearest(approx_addr)?;
@@ -440,15 +439,15 @@ pub struct PerforationInformation {
     /// Byte 6 bit 7: switching flag
     pub count_switching_flag: bool,
     /// Byte 6 bit 6-0: perforation decimal
-    pub perf_decimal: u8, 
+    pub perf_decimal: u8,
     /// Byte 7: raw encoder pulses accumulated in current phase
-    pub pulse_number: u8
+    pub pulse_number: u8,
 }
 
 /// Perforation info from 8Eh, 2-11-8 (LS-5000)
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct PerfInformation {
-    pub perfs: Vec<PerforationInformation>
+    pub perfs: Vec<PerforationInformation>,
 }
 
 impl PerfInformation {
@@ -462,9 +461,7 @@ impl PerfInformation {
         let head: &[u8; Self::HEAD] = b.get(..Self::HEAD)?.try_into().ok()?;
 
         let parameter_length =
-            ((head[0] as usize) << 16) |
-            ((head[1] as usize) << 8) |
-            (head[2] as usize);
+            ((head[0] as usize) << 16) | ((head[1] as usize) << 8) | (head[2] as usize);
 
         let bytes_per_parameter = usize::from(head[3]);
 
@@ -511,7 +508,9 @@ impl PerfInformation {
     }
 
     pub fn nearest(&self, addr: u32) -> Option<&PerforationInformation> {
-        self.perfs.iter().min_by_key(|p| Self::address(p).abs_diff(addr))
+        self.perfs
+            .iter()
+            .min_by_key(|p| Self::address(p).abs_diff(addr))
     }
 }
 
@@ -521,10 +520,7 @@ impl fmt::Display for PerforationInformation {
         writeln!(
             f,
             "{},{},{},{}",
-            self.perf_number,
-            self.perf_decimal,
-            self.count_switching_flag,
-            self.pulse_number,
+            self.perf_number, self.perf_decimal, self.count_switching_flag, self.pulse_number,
         )
     }
 }

--- a/src/protocol/data.rs
+++ b/src/protocol/data.rs
@@ -1,7 +1,5 @@
 //! READ and SEND data types. Section 2-11
 
-use std::fmt;
-
 use super::{caps::other::DataTypes, sense::Coop};
 use crate::error::Error;
 use bitflags::bitflags;
@@ -501,27 +499,19 @@ impl PerfInformation {
     }
 
     /// encoder-space address for a given perforation reading
+    /// used for calculating closest perf match to a given line address
     fn address(perf: &PerforationInformation) -> u32 {
         7 * (108 * perf.perf_number as u32
             + 22 * perf.perf_decimal as u32
             + perf.pulse_number as u32)
     }
 
+    /// find nearest perf match corresponding to an image address
+    /// there's ~19 addresses per perf leading to a granularity of ~0.25mm (4.75mm perf pitch)
     pub fn nearest(&self, addr: u32) -> Option<&PerforationInformation> {
         self.perfs
             .iter()
             .min_by_key(|p| Self::address(p).abs_diff(addr))
-    }
-}
-
-impl fmt::Display for PerforationInformation {
-    // perf_number,num_pattern,count_switching_flag,pulse_number
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(
-            f,
-            "{},{},{},{}",
-            self.perf_number, self.perf_decimal, self.count_switching_flag, self.pulse_number,
-        )
     }
 }
 

--- a/src/protocol/data.rs
+++ b/src/protocol/data.rs
@@ -216,6 +216,18 @@ impl DataType {
             },
         }
     }
+
+    pub fn qualifier(self) -> Option<(u8, u8)> {
+        match self {
+            Self::Boundary2 => Some((0, 0x3B)),
+            _ => self.row().width.map(|width| {
+                (
+                    width,
+                    width_code(width).expect("2-11-2 widths are all encodable"),
+                )
+            }),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -267,6 +279,12 @@ pub const fn width_code(width: u8) -> Option<u8> {
     })
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FrameTable {
+    Boundary(Boundary),
+    BoundaryType2(BoundaryType2),
+}
+
 /// One frame's rectangle as `DataType::Boundary` carries it, 2-11-6
 ///
 /// Sub-scanning is Y and main-scanning is X, and this record puts them in that
@@ -282,6 +300,30 @@ pub struct Rect {
     pub bottom: u32,
     /// Bytes 16-19, lower right in the main-scanning direction
     pub right: u32,
+}
+
+/// One frame's rectangle as `DataType::BoundaryType2` carries it, 2-11-9 (LS-5000)
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct FramePosition {
+    /// Bytes 4-7, Y address for line 1
+    pub top: u32,
+    /// Bytes 8-9, perforation number
+    pub perf_number: u16,
+    /// Byte 10, perforation decimal
+    pub perf_decimal: u8,
+    /// Byte 11, pulse number
+    pub pulse: u8,
+}
+
+impl FramePosition {
+    pub fn rect(self, x_start: u32, x_boundary: u32, length: u32) -> Rect {
+        Rect {
+            top: self.top,
+            left: x_start,
+            bottom: self.top + length - 1,
+            right: x_start + x_boundary - 1,
+        }
+    }
 }
 
 /// Boundary information, 2-11-6, `DataType::Boundary`
@@ -362,6 +404,101 @@ impl Boundary {
                 out.extend_from_slice(&v.to_be_bytes());
             }
         }
+        Ok(out)
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct BoundaryType2 {
+    pub frames: Vec<FramePosition>,
+}
+
+impl BoundaryType2 {
+    /// Bytes before the first frame.
+    const HEAD: usize = 4;
+
+    /// Bytes occupied by each frame record.
+    const FRAME: usize = 8;
+
+    pub fn from_bytes(b: &[u8]) -> Option<Self> {
+        let head: &[u8; Self::HEAD] = b.get(..Self::HEAD)?.try_into().ok()?;
+
+        // Bytes 0-1: parameter length, which is total length - 1.
+        let parameter_length = u16::from_be_bytes([head[0], head[1]]) as usize;
+
+        // Byte 2: actual number of images.
+        let count = usize::from(head[2]);
+
+        // The parameter length describes everything following the field
+        // itself, i.e. total parameter size is length + 1.
+        let total = parameter_length.checked_add(1)?;
+
+        // The reserved byte is currently ignored.
+        let expected = Self::HEAD.checked_add(count.checked_mul(Self::FRAME)?)?;
+
+        // Reject truncated or structurally inconsistent data.
+        if total != expected || b.len() < total {
+            return None;
+        }
+
+        let mut frames = Vec::with_capacity(count);
+
+        for n in 0..count {
+            let at = Self::HEAD + n * Self::FRAME;
+            let r = b.get(at..at + Self::FRAME)?;
+
+            frames.push(FramePosition {
+                top: u32::from_be_bytes([r[0], r[1], r[2], r[3]]),
+                perf_number: u16::from_be_bytes([r[4], r[5]]),
+                perf_decimal: r[6],
+                pulse: r[7],
+            });
+        }
+
+        Some(Self { frames })
+    }
+
+    pub fn to_bytes(&self) -> Result<Vec<u8>, Error> {
+        if self.frames.len() > u8::MAX as usize {
+            return Err(Error::Unsupported {
+                op: "boundary_type2",
+                reason: format!(
+                    "{} frames cannot fit the one-byte count field",
+                    self.frames.len()
+                ),
+            });
+        }
+
+        let total = Self::HEAD
+            .checked_add(self.frames.len() * Self::FRAME)
+            .ok_or_else(|| Error::Unsupported {
+                op: "boundary_type2",
+                reason: "boundary information is too large".into(),
+            })?;
+
+        // Parameter length is n - 1, where n is the total parameter size.
+        let parameter_length = total - 1;
+
+        if parameter_length > u16::MAX as usize {
+            return Err(Error::Unsupported {
+                op: "boundary_type2",
+                reason: "boundary information is too large".into(),
+            });
+        }
+
+        let mut out = Vec::with_capacity(total);
+
+        out.extend_from_slice(&(parameter_length as u16).to_be_bytes());
+        out.push(self.frames.len() as u8);
+        out.push(0);
+
+        for frame in &self.frames {
+            out.extend_from_slice(&frame.top.to_be_bytes());
+            out.extend_from_slice(&frame.perf_number.to_be_bytes());
+            out.push(frame.perf_decimal);
+            out.push(frame.pulse);
+        }
+
         Ok(out)
     }
 }

--- a/src/protocol/data.rs
+++ b/src/protocol/data.rs
@@ -329,6 +329,8 @@ impl FramePosition {
 
     /// construct a FramePosition entry from detected y_start, as pixel location on the thumb strip
     /// all other values are inferred using data read from 8Eh PerforationInformation
+    /// the only valid positions on a strip are locations returned from 8Eh so we need to find the closest match
+    /// in the table of returned positions, then use that as an index for the scanner's boundary information data
     pub fn new(
         dpi_device: u16,
         dpi_thumb: u16,
@@ -507,7 +509,7 @@ impl PerfInformation {
     }
 
     /// find nearest perf match corresponding to an image address
-    /// there's ~19 addresses per perf leading to a granularity of ~0.25mm (4.75mm perf pitch)
+    /// there's ~19 addresses per perf leading to a granularity of ~0.25mm with 35mm film (4.75mm perf pitch)
     pub fn nearest(&self, addr: u32) -> Option<&PerforationInformation> {
         self.perfs
             .iter()

--- a/src/protocol/decode.rs
+++ b/src/protocol/decode.rs
@@ -749,6 +749,8 @@ mod transposed {
             ccd_lines: 3,
             registration_gap: gap,
             granule: 1,
+            truncated_bytes_line: (0, 0),
+            truncated_lines_frame: (0, 0),
         }
     }
 
@@ -866,6 +868,8 @@ mod transposed {
             ccd_lines: 1,
             registration_gap: 1,
             granule: 1,
+            truncated_bytes_line: (0, 0),
+            truncated_lines_frame: (0, 0),
         }
     }
 

--- a/src/protocol/image.rs
+++ b/src/protocol/image.rs
@@ -256,21 +256,12 @@ impl Layout {
     ///
     /// Takes truncated bytes reported by driver from LS-4x/LS-5x in account
     pub fn total_bytes(&self) -> u64 {
-        if !self.override_size {
-            return u64::from(self.bytes_per_line())
-                * u64::from(
-                    self.lines
-                        + self.truncated_lines_frame.0
-                        + self.truncated_lines_frame.1
-            )
-        } else {
-            return self.overridden_size as u64;
-        }
-    }
-
-    pub fn override_size(&mut self, size: usize) {
-        self.override_size = true;
-        self.overridden_size = size;
+        return u64::from(self.bytes_per_line())
+            * u64::from(
+                self.lines
+                    + self.truncated_lines_frame.0
+                    + self.truncated_lines_frame.1
+        )
     }
 
     /// Readouts the unit emits per line

--- a/src/protocol/image.rs
+++ b/src/protocol/image.rs
@@ -3,8 +3,6 @@
 //! Image data carries no header and no length of its own, so [`Layout`] is the
 //! only thing that says how much there is to read and how it is shaped.
 
-use tracing::debug;
-
 use crate::{
     error::Error,
     protocol::{
@@ -12,7 +10,10 @@ use crate::{
             Capabilities,
             address::Transfer,
             set_window::{ColorInterleaving, ScanKind},
-        }, data::{Truncation, width_code}, model::Model, window::{Channel, Window, validate_set}
+        },
+        data::{Truncation, width_code},
+        model::Model,
+        window::{Channel, Window, validate_set},
     },
 };
 
@@ -57,8 +58,6 @@ pub struct Layout {
     pub truncated_bytes_line: (u32, u32),
     /// Invalid lines attached to every image, so total lines before the first and after the last line per 2-11-5-3
     pub truncated_lines_frame: (u32, u32),
-    pub override_size: bool,
-    pub overridden_size: usize
 }
 
 impl Layout {
@@ -83,8 +82,6 @@ impl Layout {
             granule: 1,
             truncated_bytes_line: (0, 0),
             truncated_lines_frame: (0, 0),
-            override_size: false,
-            overridden_size: 0
         }
     }
 }
@@ -134,7 +131,7 @@ fn pitches(caps: &Capabilities, window: &Window) -> Result<(u32, u32), Error> {
 /// the unit constrains nothing, so any length will do
 fn read_granule(caps: &Capabilities, line: usize, channels: usize) -> usize {
     if caps.identity.model() == Some(Model::Ls50) {
-        return 1024
+        return 1024;
     }
 
     let transfer = caps.address.transfer;
@@ -152,7 +149,12 @@ impl Layout {
     /// Work out what a scan of `windows` will produce
     ///
     /// `divisor` is the measurement unit in force, from the mode page
-    pub fn new(caps: &Capabilities, windows: &[Window], divisor: u16, truncated_by_driver: Option<&Truncation>) -> Result<Self, Error> {
+    pub fn new(
+        caps: &Capabilities,
+        windows: &[Window],
+        divisor: u16,
+        truncated_by_driver: Option<&Truncation>,
+    ) -> Result<Self, Error> {
         // Every rule about the set itself, including that they agree on
         // everything shaping the stream
         validate_set(windows)?;
@@ -164,7 +166,7 @@ impl Layout {
         // A window coordinate is one sensor step only at the unit's maximum
         // resolution. At 1200 it is coarser, so the sizes scale to the sensor
         // before the pitch divides them
-        let (mut pixels, lines) = if divisor == COARSE_DIVISOR {
+        let (pixels, lines) = if divisor == COARSE_DIVISOR {
             let scale = |v: u32, p: u32| {
                 (u64::from(v) * u64::from(optical) / (u64::from(COARSE_DIVISOR) * u64::from(p)))
                     as u32
@@ -187,21 +189,16 @@ impl Layout {
         let line = pixels as usize * usize::from(bytes_per_sample);
         let granule = read_granule(caps, line, channels.len());
 
-        let mut truncated_bytes_line  = (0, 0);
+        let mut truncated_bytes_line = (0, 0);
         let mut truncated_lines_frame = (0, 0);
 
         if let Some(t) = truncated_by_driver {
             truncated_bytes_line = (
-                u32::from(t.per_color.first)
-                    + u32::from(t.all_colors.first),
-                u32::from(t.per_color.last)
-                    + u32::from(t.all_colors.last),
+                u32::from(t.per_color.first) + u32::from(t.all_colors.first),
+                u32::from(t.per_color.last) + u32::from(t.all_colors.last),
             );
 
-            truncated_lines_frame = (
-                u32::from(t.lines.first),
-                u32::from(t.lines.last),
-            );
+            truncated_lines_frame = (u32::from(t.lines.first), u32::from(t.lines.last));
         }
 
         Ok(Self {
@@ -223,8 +220,6 @@ impl Layout {
             granule,
             truncated_bytes_line,
             truncated_lines_frame,
-            overridden_size: 0,
-            override_size: false
         })
     }
 
@@ -245,9 +240,7 @@ impl Layout {
 
     /// Bytes in one line of every channel
     pub fn bytes_per_line(&self) -> u32 {
-        self.pixels
-            * u32::from(self.bytes_per_sample)
-            * self.readouts()
+        self.pixels * u32::from(self.bytes_per_sample) * self.readouts()
             + self.truncated_bytes_line.0
             + self.truncated_bytes_line.1
     }
@@ -256,12 +249,8 @@ impl Layout {
     ///
     /// Takes truncated bytes reported by driver from LS-4x/LS-5x in account
     pub fn total_bytes(&self) -> u64 {
-        return u64::from(self.bytes_per_line())
-            * u64::from(
-                self.lines
-                    + self.truncated_lines_frame.0
-                    + self.truncated_lines_frame.1
-        )
+        u64::from(self.bytes_per_line())
+            * u64::from(self.lines + self.truncated_lines_frame.0 + self.truncated_lines_frame.1)
     }
 
     /// Readouts the unit emits per line
@@ -361,7 +350,13 @@ mod tests {
     /// dpi, one channel, 16 bit, which read back 80000 bytes off the hardware
     #[test]
     fn the_first_real_scan_still_measures_80000_bytes() {
-        let l = Layout::new(&caps(0x01, 12, 3), &[window(1, 666, (1200, 1200))], 4000).unwrap();
+        let l = Layout::new(
+            &caps(0x01, 12, 3),
+            &[window(1, 666, (1200, 1200))],
+            4000,
+            None,
+        )
+        .unwrap();
 
         assert_eq!(l.pitch, 6);
         assert_eq!((l.pixels, l.lines), (200, 200));
@@ -386,7 +381,8 @@ mod tests {
             (334, 666, 6),
             (333, 333, 12),
         ] {
-            let l = Layout::new(&caps(0x01, 12, 3), &rgb(asked, (12000, 12000)), 4000).unwrap();
+            let l =
+                Layout::new(&caps(0x01, 12, 3), &rgb(asked, (12000, 12000)), 4000, None).unwrap();
             assert_eq!((l.pitch, l.dpi), (pitch, dpi), "{asked} dpi");
             assert_eq!(l.pixels, 12000 / pitch, "{asked} dpi");
         }
@@ -402,7 +398,7 @@ mod tests {
         windows[0].composition = Composition::MultilevelBW;
         windows[0].scanning_kind = ScanKind::THUMBNAIL;
 
-        let l = Layout::new(&caps(0x01, 12, 3), &windows, 4000).unwrap();
+        let l = Layout::new(&caps(0x01, 12, 3), &windows, 4000, None).unwrap();
         assert_eq!(l.pitch, 48);
         assert_eq!((l.pixels, l.lines), (186, 721));
         assert_eq!(l.total_bytes(), 268212);
@@ -410,7 +406,7 @@ mod tests {
         // The same window as an image snaps to the ladder instead
         windows[0].scanning_kind = ScanKind::IMAGE;
         assert_eq!(
-            Layout::new(&caps(0x01, 12, 3), &windows, 4000)
+            Layout::new(&caps(0x01, 12, 3), &windows, 4000, None)
                 .unwrap()
                 .pitch,
             12
@@ -421,7 +417,7 @@ mod tests {
     /// 1666x100 on hardware, half the lines a square 666 gives, so it is not
     #[test]
     fn a_half_y_resolution_halves_the_lines() {
-        let square = Layout::new(&caps(0x01, 12, 3), &rgb(666, (10000, 1200)), 4000).unwrap();
+        let square = Layout::new(&caps(0x01, 12, 3), &rgb(666, (10000, 1200)), 4000, None).unwrap();
         assert_eq!((square.pixels, square.lines), (1666, 200));
         assert_eq!(square.total_bytes(), 1999200);
 
@@ -429,7 +425,7 @@ mod tests {
         for w in &mut half {
             w.resolution = (666, 333);
         }
-        let half = Layout::new(&caps(0x01, 12, 3), &half, 4000).unwrap();
+        let half = Layout::new(&caps(0x01, 12, 3), &half, 4000, None).unwrap();
         assert_eq!((half.pixels, half.lines), (1666, 100));
         assert_eq!(half.total_bytes(), 999600);
         // X is untouched by it
@@ -451,8 +447,8 @@ mod tests {
     #[test]
     fn the_coarse_divisor_scales_the_window_to_pixels() {
         let windows = rgb(4000, (1200, 2400));
-        let fine = Layout::new(&caps(0x01, 12, 3), &windows, 4000).unwrap();
-        let coarse = Layout::new(&caps(0x01, 12, 3), &windows, 1200).unwrap();
+        let fine = Layout::new(&caps(0x01, 12, 3), &windows, 4000, None).unwrap();
+        let coarse = Layout::new(&caps(0x01, 12, 3), &windows, 1200, None).unwrap();
 
         assert_eq!((fine.pixels, fine.lines), (1200, 2400));
         assert_eq!((coarse.pixels, coarse.lines), (4000, 8000));
@@ -465,7 +461,7 @@ mod tests {
         let windows = rgb(4000, (10000, 13860));
         let line = 10000 * 2;
         let granule = |transfer| {
-            Layout::new(&caps(transfer, 1, 2), &windows, 4000)
+            Layout::new(&caps(transfer, 1, 2), &windows, 4000, None)
                 .unwrap()
                 .granule
         };
@@ -479,14 +475,14 @@ mod tests {
     #[test]
     fn multiple_reading_multiplies_the_byte_count() {
         let mut windows = rgb(4000, (10000, 13860));
-        let single = Layout::new(&caps(0x01, 12, 3), &windows, 4000).unwrap();
+        let single = Layout::new(&caps(0x01, 12, 3), &windows, 4000, None).unwrap();
         assert_eq!(single.readings_per_line, 1);
         assert_eq!(single.total_bytes(), 10000 * 2 * 3 * 13860);
 
         for w in &mut windows {
             w.multiple_reading = 15;
         }
-        let sixteen = Layout::new(&caps(0x01, 12, 3), &windows, 4000).unwrap();
+        let sixteen = Layout::new(&caps(0x01, 12, 3), &windows, 4000, None).unwrap();
         assert_eq!(sixteen.readings_per_line, 16);
         assert_eq!(sixteen.total_bytes(), single.total_bytes() * 16);
     }
@@ -495,7 +491,7 @@ mod tests {
     #[test]
     fn the_registration_gap_shrinks_with_the_pitch() {
         let gap = |dpi| {
-            Layout::new(&caps(0x01, 12, 3), &rgb(dpi, (10000, 13860)), 4000)
+            Layout::new(&caps(0x01, 12, 3), &rgb(dpi, (10000, 13860)), 4000, None)
                 .unwrap()
                 .registration_gap
         };
@@ -509,7 +505,7 @@ mod tests {
         for w in &mut preview {
             w.resolution = (666, 333);
         }
-        let preview = Layout::new(&caps(0x01, 12, 3), &preview, 4000).unwrap();
+        let preview = Layout::new(&caps(0x01, 12, 3), &preview, 4000, None).unwrap();
         assert_eq!((preview.pitch, preview.line_pitch), (6, 12));
         assert_eq!(preview.registration_gap, 1);
     }
@@ -518,17 +514,17 @@ mod tests {
     fn a_window_set_that_disagrees_has_no_layout() {
         let mut windows = rgb(4000, (10000, 13860));
         windows[2].size.0 = 9000;
-        assert!(Layout::new(&caps(0x01, 12, 3), &windows, 4000).is_err());
+        assert!(Layout::new(&caps(0x01, 12, 3), &windows, 4000, None).is_err(),);
 
         // Exposure is what a set is allowed to differ in
         let mut windows = rgb(4000, (10000, 13860));
         windows[2].exposure = 71125;
-        assert!(Layout::new(&caps(0x01, 12, 3), &windows, 4000).is_ok());
+        assert!(Layout::new(&caps(0x01, 12, 3), &windows, 4000, None).is_ok(),);
     }
 
     #[test]
     fn an_empty_window_set_has_no_layout() {
-        assert!(Layout::new(&caps(0x01, 12, 3), &[], 4000).is_err());
+        assert!(Layout::new(&caps(0x01, 12, 3), &[], 4000, None).is_err());
     }
 }
 
@@ -553,6 +549,8 @@ mod readouts {
             ccd_lines: 3,
             registration_gap: 1,
             granule: 1,
+            truncated_bytes_line: (0, 0),
+            truncated_lines_frame: (0, 0),
         }
     }
 

--- a/src/protocol/image.rs
+++ b/src/protocol/image.rs
@@ -10,7 +10,7 @@ use crate::{
             Capabilities,
             address::Transfer,
             set_window::{ColorInterleaving, ScanKind},
-        }, data::width_code, model::Model, window::{Channel, Window, validate_set}
+        }, data::{Truncation, width_code}, model::Model, window::{Channel, Window, validate_set}
     },
 };
 
@@ -51,6 +51,14 @@ pub struct Layout {
     /// The transfer length every READ has to be a whole number of. 1 means the
     /// unit constrains nothing
     pub granule: usize,
+    /// Invalid bytes attached to every scan line, per 2-11-5-3
+    pub truncated_bytes_per_line: u32,
+    /// Invalid lines attached before the image
+    pub truncated_lines_top: u32,
+    /// Invalid lines attached after the image
+    pub truncated_lines_bottom: u32,
+    pub override_size: bool,
+    pub overridden_size: usize
 }
 
 impl Layout {
@@ -73,6 +81,11 @@ impl Layout {
             ccd_lines: 1,
             registration_gap: 0,
             granule: 1,
+            truncated_bytes_per_line: 0,
+            truncated_lines_bottom: 0,
+            truncated_lines_top: 0,
+            override_size: false,
+            overridden_size: 0
         }
     }
 }
@@ -121,8 +134,8 @@ fn pitches(caps: &Capabilities, window: &Window) -> Result<(u32, u32), Error> {
 /// Bit 1 makes it a line across every color, bit 2 one line. Neither set means
 /// the unit constrains nothing, so any length will do
 fn read_granule(caps: &Capabilities, line: usize, channels: usize) -> usize {
-    if caps.identity.model() == Some(Model::Ls50) { // LS50 always produces blocks of 131072b
-        return 1
+    if caps.identity.model() == Some(Model::Ls50) {
+        return 1024
     }
 
     let transfer = caps.address.transfer;
@@ -140,7 +153,7 @@ impl Layout {
     /// Work out what a scan of `windows` will produce
     ///
     /// `divisor` is the measurement unit in force, from the mode page
-    pub fn new(caps: &Capabilities, windows: &[Window], divisor: u16) -> Result<Self, Error> {
+    pub fn new(caps: &Capabilities, windows: &[Window], divisor: u16, truncated_by_driver: Option<&Truncation>) -> Result<Self, Error> {
         // Every rule about the set itself, including that they agree on
         // everything shaping the stream
         validate_set(windows)?;
@@ -152,7 +165,7 @@ impl Layout {
         // A window coordinate is one sensor step only at the unit's maximum
         // resolution. At 1200 it is coarser, so the sizes scale to the sensor
         // before the pitch divides them
-        let (pixels, lines) = if divisor == COARSE_DIVISOR {
+        let (mut pixels, lines) = if divisor == COARSE_DIVISOR {
             let scale = |v: u32, p: u32| {
                 (u64::from(v) * u64::from(optical) / (u64::from(COARSE_DIVISOR) * u64::from(p)))
                     as u32
@@ -175,6 +188,21 @@ impl Layout {
         let line = pixels as usize * usize::from(bytes_per_sample);
         let granule = read_granule(caps, line, channels.len());
 
+        let mut truncated_bytes_per_line = 0;
+        let mut truncated_lines_top = 0;
+        let mut truncated_lines_bottom = 0;
+
+        if let Some(t) = truncated_by_driver {
+            truncated_bytes_per_line =
+                u32::from(t.per_color.first)
+                + u32::from(t.per_color.last)
+                + u32::from(t.all_colors.first)
+                + u32::from(t.all_colors.last);
+
+            truncated_lines_top = u32::from(t.lines.first);
+            truncated_lines_bottom = u32::from(t.lines.last);
+        }
+
         Ok(Self {
             pixels,
             lines,
@@ -192,6 +220,11 @@ impl Layout {
             // two pitches are equal except in a preview, which halves only Y
             registration_gap: u32::from(caps.address.line_gap) / line_pitch,
             granule,
+            truncated_bytes_per_line,
+            truncated_lines_bottom,
+            truncated_lines_top,
+            overridden_size: 0,
+            override_size: false
         })
     }
 
@@ -211,22 +244,32 @@ impl Layout {
     }
 
     /// Bytes in one line of every channel
-    pub fn bytes_per_line(&self) -> u64 {
-        u64::from(self.pixels) * u64::from(self.bytes_per_sample) * self.channels.len() as u64
+    pub fn bytes_per_line(&self) -> u32 {
+        self.pixels
+            * u32::from(self.bytes_per_sample)
+            * self.readouts()
+            + self.truncated_bytes_per_line
     }
 
     /// How many bytes the whole scan will hand back
     ///
-    /// The modes that raise a cooperative request are the ones this can be
-    /// wrong for: the
-    /// multi-line record reports its own byte and line counts, and a scan whose
-    /// CCD lines need re-registering carries extra lines at the seams. Prefer
-    /// the unit's numbers where it gives them
+    /// Takes truncated bytes reported by driver from LS-4x/LS-5x in account
     pub fn total_bytes(&self) -> u64 {
-        u64::from(self.pixels)
-            * u64::from(self.lines)
-            * u64::from(self.bytes_per_sample)
-            * u64::from(self.readouts())
+        if !self.override_size {
+        return u64::from(self.bytes_per_line())
+            * u64::from(
+                self.lines
+                    + self.truncated_lines_top
+                    + self.truncated_lines_bottom
+            )
+        } else {
+            return self.overridden_size as u64;
+        }
+    }
+
+    pub fn override_size(&mut self, size: usize) {
+        self.override_size = true;
+        self.overridden_size = size;
     }
 
     /// Readouts the unit emits per line

--- a/src/protocol/image.rs
+++ b/src/protocol/image.rs
@@ -53,12 +53,10 @@ pub struct Layout {
     /// The transfer length every READ has to be a whole number of. 1 means the
     /// unit constrains nothing
     pub granule: usize,
-    /// Invalid bytes attached to every scan line, per 2-11-5-3
-    pub truncated_bytes_per_line: u32,
-    /// Invalid lines attached before the image
-    pub truncated_lines_top: u32,
-    /// Invalid lines attached after the image
-    pub truncated_lines_bottom: u32,
+    /// Invalid bytes attached to every scan line, at start and end per 2-11-5-3
+    pub truncated_bytes_line: (u32, u32),
+    /// Invalid lines attached to every image, so total lines before the first and after the last line per 2-11-5-3
+    pub truncated_lines_frame: (u32, u32),
     pub override_size: bool,
     pub overridden_size: usize
 }
@@ -83,9 +81,8 @@ impl Layout {
             ccd_lines: 1,
             registration_gap: 0,
             granule: 1,
-            truncated_bytes_per_line: 0,
-            truncated_lines_bottom: 0,
-            truncated_lines_top: 0,
+            truncated_bytes_line: (0, 0),
+            truncated_lines_frame: (0, 0),
             override_size: false,
             overridden_size: 0
         }
@@ -190,19 +187,21 @@ impl Layout {
         let line = pixels as usize * usize::from(bytes_per_sample);
         let granule = read_granule(caps, line, channels.len());
 
-        let mut truncated_bytes_per_line = 0;
-        let mut truncated_lines_top = 0;
-        let mut truncated_lines_bottom = 0;
+        let mut truncated_bytes_line  = (0, 0);
+        let mut truncated_lines_frame = (0, 0);
 
         if let Some(t) = truncated_by_driver {
-            truncated_bytes_per_line =
+            truncated_bytes_line = (
                 u32::from(t.per_color.first)
-                + u32::from(t.per_color.last)
-                + u32::from(t.all_colors.first)
-                + u32::from(t.all_colors.last);
+                    + u32::from(t.all_colors.first),
+                u32::from(t.per_color.last)
+                    + u32::from(t.all_colors.last),
+            );
 
-            truncated_lines_top = u32::from(t.lines.first);
-            truncated_lines_bottom = u32::from(t.lines.last);
+            truncated_lines_frame = (
+                u32::from(t.lines.first),
+                u32::from(t.lines.last),
+            );
         }
 
         Ok(Self {
@@ -222,9 +221,8 @@ impl Layout {
             // two pitches are equal except in a preview, which halves only Y
             registration_gap: u32::from(caps.address.line_gap) / line_pitch,
             granule,
-            truncated_bytes_per_line,
-            truncated_lines_bottom,
-            truncated_lines_top,
+            truncated_bytes_line,
+            truncated_lines_frame,
             overridden_size: 0,
             override_size: false
         })
@@ -250,7 +248,8 @@ impl Layout {
         self.pixels
             * u32::from(self.bytes_per_sample)
             * self.readouts()
-            + self.truncated_bytes_per_line
+            + self.truncated_bytes_line.0
+            + self.truncated_bytes_line.1
     }
 
     /// How many bytes the whole scan will hand back
@@ -261,8 +260,8 @@ impl Layout {
             return u64::from(self.bytes_per_line())
                 * u64::from(
                     self.lines
-                        + self.truncated_lines_top
-                        + self.truncated_lines_bottom
+                        + self.truncated_lines_frame.0
+                        + self.truncated_lines_frame.1
             )
         } else {
             return self.overridden_size as u64;

--- a/src/protocol/image.rs
+++ b/src/protocol/image.rs
@@ -3,6 +3,8 @@
 //! Image data carries no header and no length of its own, so [`Layout`] is the
 //! only thing that says how much there is to read and how it is shaped.
 
+use tracing::debug;
+
 use crate::{
     error::Error,
     protocol::{
@@ -256,11 +258,11 @@ impl Layout {
     /// Takes truncated bytes reported by driver from LS-4x/LS-5x in account
     pub fn total_bytes(&self) -> u64 {
         if !self.override_size {
-        return u64::from(self.bytes_per_line())
-            * u64::from(
-                self.lines
-                    + self.truncated_lines_top
-                    + self.truncated_lines_bottom
+            return u64::from(self.bytes_per_line())
+                * u64::from(
+                    self.lines
+                        + self.truncated_lines_top
+                        + self.truncated_lines_bottom
             )
         } else {
             return self.overridden_size as u64;

--- a/src/protocol/image.rs
+++ b/src/protocol/image.rs
@@ -10,9 +10,7 @@ use crate::{
             Capabilities,
             address::Transfer,
             set_window::{ColorInterleaving, ScanKind},
-        },
-        data::width_code,
-        window::{Channel, Window, validate_set},
+        }, data::width_code, model::Model, window::{Channel, Window, validate_set}
     },
 };
 
@@ -123,7 +121,12 @@ fn pitches(caps: &Capabilities, window: &Window) -> Result<(u32, u32), Error> {
 /// Bit 1 makes it a line across every color, bit 2 one line. Neither set means
 /// the unit constrains nothing, so any length will do
 fn read_granule(caps: &Capabilities, line: usize, channels: usize) -> usize {
+    if caps.identity.model() == Some(Model::Ls50) { // LS50 always produces blocks of 131072b
+        return 1
+    }
+
     let transfer = caps.address.transfer;
+
     if transfer.contains(Transfer::READ_LINE_COLS) {
         (line * channels).max(1)
     } else if transfer.contains(Transfer::READ_LINE) {

--- a/src/scan/autoexpose.rs
+++ b/src/scan/autoexpose.rs
@@ -110,7 +110,6 @@ impl AutoExposure {
 pub(crate) fn prescan_windows(caps: &Capabilities, windows: &[Window]) -> Vec<Window> {
     let dpi = caps.address.x_axis.dpi_range.start;
     let fast = caps.set_window.mode.contains(ScanMode::HIGH_SPEED);
-    let mf = caps.identity.is_mf();
 
     windows
         .iter()
@@ -120,7 +119,7 @@ pub(crate) fn prescan_windows(caps: &Capabilities, windows: &[Window]) -> Vec<Wi
             // averaging bit. The captures pair 666x333 with byte 41 = 01h and
             // high speed every time
             // LS-5x always prescans at 285dpi
-            w.resolution = if mf { (dpi, dpi / 2) } else { (285, 285) };
+            w.resolution = if caps.identity.is_mf_scanner() { (dpi, dpi / 2) } else { (285, 285) };
             w.flags.remove(Flags::AVERAGING);
             if fast {
                 w.scanning_mode = ScanMode::HIGH_SPEED;

--- a/src/scan/autoexpose.rs
+++ b/src/scan/autoexpose.rs
@@ -110,6 +110,7 @@ impl AutoExposure {
 pub(crate) fn prescan_windows(caps: &Capabilities, windows: &[Window]) -> Vec<Window> {
     let dpi = caps.address.x_axis.dpi_range.start;
     let fast = caps.set_window.mode.contains(ScanMode::HIGH_SPEED);
+    let mf = caps.identity.is_mf();
 
     windows
         .iter()
@@ -118,7 +119,8 @@ pub(crate) fn prescan_windows(caps: &Capabilities, windows: &[Window]) -> Vec<Wi
             // A preview halves Y where a scan is square, and runs without the
             // averaging bit. The captures pair 666x333 with byte 41 = 01h and
             // high speed every time
-            w.resolution = (dpi, dpi / 2);
+            // LS-5x always prescans at 285dpi
+            w.resolution = if mf { (dpi, dpi / 2) } else { (285, 285) };
             w.flags.remove(Flags::AVERAGING);
             if fast {
                 w.scanning_mode = ScanMode::HIGH_SPEED;

--- a/src/scan/autoexpose.rs
+++ b/src/scan/autoexpose.rs
@@ -119,7 +119,11 @@ pub(crate) fn prescan_windows(caps: &Capabilities, windows: &[Window]) -> Vec<Wi
             // averaging bit. The captures pair 666x333 with byte 41 = 01h and
             // high speed every time
             // LS-5x always prescans at 285dpi
-            w.resolution = if caps.identity.is_mf_scanner() { (dpi, dpi / 2) } else { (285, 285) };
+            w.resolution = if caps.identity.is_mf_scanner() {
+                (dpi, dpi / 2)
+            } else {
+                (285, 285)
+            };
             w.flags.remove(Flags::AVERAGING);
             if fast {
                 w.scanning_mode = ScanMode::HIGH_SPEED;

--- a/src/scan/framing.rs
+++ b/src/scan/framing.rs
@@ -49,9 +49,9 @@ impl Framing {
         if caps
             .features
             .data_types
-            .contains(DataTypes::BOUNDARY2_READ)
+            .contains(DataTypes::PERFORATION_READ)
         {
-            return Self::Thumbnail;
+            return Self::Perforation;
         }
         Self::Caller
     }

--- a/src/scan/framing.rs
+++ b/src/scan/framing.rs
@@ -49,9 +49,9 @@ impl Framing {
         if caps
             .features
             .data_types
-            .contains(DataTypes::PERFORATION_READ)
+            .contains(DataTypes::BOUNDARY2_READ)
         {
-            return Self::Perforation;
+            return Self::Thumbnail;
         }
         Self::Caller
     }

--- a/src/scan/meter.rs
+++ b/src/scan/meter.rs
@@ -280,7 +280,7 @@ mod tests {
                 }
             }
         }
-        let layout = Layout::new(&caps(), windows, 4000).unwrap();
+        let layout = Layout::new(&caps(), windows, 4000, None).unwrap();
         let mut decoder = Decoder::new(&layout).unwrap();
         let mut samples = Samples::default();
         samples.resize_for(&decoder);

--- a/src/scan/pass.rs
+++ b/src/scan/pass.rs
@@ -19,7 +19,7 @@ pub struct Pass {
     /// The stream's shape, as far as 2-10's formula describes it
     pub layout: Layout,
     /// What the unit asked the host to do with the data, if anything
-    pub cooperation: Option<CooperativeAction>,
+    pub cooperation: Vec<CooperativeAction>,
     /// Whether every block the layout promised arrived
     pub complete: bool,
     /// Image rows and columns: the sensor (the layout's pixels) and the feed

--- a/src/scan/thumbnail.rs
+++ b/src/scan/thumbnail.rs
@@ -22,6 +22,7 @@ use crate::{
         },
         data::{Boundary, BoundaryType2, FramePosition, PerfInformation, Rect},
         decode::{Image, Samples},
+        model::Model,
         window::{Flags, Window},
     },
 };
@@ -108,6 +109,7 @@ pub fn frames_type2(
 
     let found = boundaries::detect(&image, (length / pitch) as usize, polarity);
 
+    // genereate FramePosition table using detected frame boundaries + perforation data table
     let frames: Vec<FramePosition> = found
         .frames
         .iter()
@@ -166,12 +168,15 @@ pub(crate) fn windows(caps: &Capabilities) -> Result<Vec<Window>, Error> {
         )));
     }
 
-    let (thumb_size, flags) = if caps.identity.model().unwrap().name().starts_with("LS-4")
-        || caps.identity.model().unwrap().name().starts_with("LS-5")
-    {
-        (250_278, Flags::POSITIVE | Flags::AVERAGING)
-    } else {
-        (y.address_range.last, Flags::empty())
+    let flags = match caps.identity.model() {
+        Some(Model::Ls8000 | Model::Ls9000) => Flags::empty(),
+        Some(_) => Flags::POSITIVE | Flags::AVERAGING,
+        None => {
+            return Err(Error::Unsupported {
+                op: "thumbnail window",
+                reason: "unrecognized model".into(),
+            });
+        }
     };
 
     let (left, width) = opening(caps);
@@ -184,7 +189,7 @@ pub(crate) fn windows(caps: &Capabilities) -> Result<Vec<Window>, Error> {
         // Y starts at the axis rather than the first frame, so the leading
         // edge of the film is in the pass and can be found
         w.origin = (left, y.address_range.start);
-        w.size = (width, thumb_size);
+        w.size = (width, y.address_range.last);
         w.scanning_kind = ScanKind::THUMBNAIL;
         w.scanning_mode = ScanMode::NORMAL_QUALITY;
         w.flags = flags;

--- a/src/scan/thumbnail.rs
+++ b/src/scan/thumbnail.rs
@@ -20,7 +20,7 @@ use crate::{
             Capabilities,
             set_window::{ColorInterleaving, ScanKind, ScanMode},
         },
-        data::{Boundary, Rect, BoundaryType2, FramePosition, PerfInformation},
+        data::{Boundary, BoundaryType2, FramePosition, PerfInformation, Rect},
         decode::{Image, Samples},
         window::{Flags, Window},
     },

--- a/src/scan/thumbnail.rs
+++ b/src/scan/thumbnail.rs
@@ -106,8 +106,7 @@ pub fn frames_type2(
     let origin = caps.address.y_axis.address_range.start;
     let end = caps.address.y_axis.address_range.last;
 
-    let found =
-        boundaries::detect(&image, (length / pitch) as usize, polarity);
+    let found = boundaries::detect(&image, (length / pitch) as usize, polarity);
 
     let frames: Vec<FramePosition> = found
         .frames
@@ -120,7 +119,7 @@ pub fn frames_type2(
                     caps.address.x_axis.optical_dpi,
                     caps.address.thumbnail_resolution.start,
                     frame.col as u32,
-                    &perf_info,
+                    perf_info,
                 )
             } else {
                 None
@@ -136,19 +135,6 @@ pub fn frames_type2(
     );
 
     Ok(BoundaryType2 { frames })
-}
-
-/// Perforation calculations for 8Fh BoundaryInformation Type2. Inferred from full roll previews
-/// Start offset always seems to be 28 internal units for the first perf
-fn perforation_position(y: u32) -> (u16, u8) {
-    const PERF_ORIGIN: f64 = 28.0;
-    const PERF_PITCH: f64 = 4000.0 * 4.8 / 25.4;
-
-    let position = (y as f64 - PERF_ORIGIN) / PERF_PITCH;
-    let number = position.floor() as u16;
-    let decimal = ((position - number as f64) * 5.0).floor() as u8;
-
-    (number, decimal)
 }
 
 /// Where the adapter's opening sits on the sensor, and how wide it is
@@ -180,13 +166,13 @@ pub(crate) fn windows(caps: &Capabilities) -> Result<Vec<Window>, Error> {
         )));
     }
 
-    let (thumb_size, flags) = if caps.identity.model().unwrap().name().starts_with("LS-4") ||
-                            caps.identity.model().unwrap().name().starts_with("LS-5") {
-                                (250_278, Flags::POSITIVE | Flags::AVERAGING)
-                            }
-                            else {
-                                (y.address_range.last, Flags::empty())
-                            };
+    let (thumb_size, flags) = if caps.identity.model().unwrap().name().starts_with("LS-4")
+        || caps.identity.model().unwrap().name().starts_with("LS-5")
+    {
+        (250_278, Flags::POSITIVE | Flags::AVERAGING)
+    } else {
+        (y.address_range.last, Flags::empty())
+    };
 
     let (left, width) = opening(caps);
     let mut windows = window::blank(caps, &window::color_channels(caps))?;

--- a/src/scan/thumbnail.rs
+++ b/src/scan/thumbnail.rs
@@ -20,7 +20,7 @@ use crate::{
             Capabilities,
             set_window::{ColorInterleaving, ScanKind, ScanMode},
         },
-        data::{Boundary, Rect},
+        data::{Boundary, Rect, BoundaryType2, FramePosition},
         decode::{Image, Samples},
         window::Window,
     },
@@ -84,6 +84,67 @@ pub fn frames(
         "measured the loaded strip"
     );
     Ok(Boundary { frames })
+}
+
+pub fn frames_type2(
+    caps: &Capabilities,
+    pass: &Pass,
+    samples: &[u16],
+    length: u32,
+    polarity: Option<Polarity>,
+) -> Result<BoundaryType2, Error> {
+    // The window that scans a frame has to be whole readout blocks.
+    let length = window::whole_blocks(caps, length);
+    framing::reachable(caps, length)?;
+
+    let image = Image::new(&pass.layout, samples)?;
+
+    // A thumbnail column is one line pitch of film, and the pass starts
+    // where the Y axis does, so a column is an address.
+    let pitch = pass.layout.line_pitch.max(1);
+    let origin = caps.address.y_axis.address_range.start;
+    let end = caps.address.y_axis.address_range.last;
+
+    let found =
+        boundaries::detect(&image, (length / pitch) as usize, polarity);
+
+    let frames: Vec<FramePosition> = found
+        .frames
+        .iter()
+        .map(|frame| origin + frame.col as u32 * pitch)
+        .filter(|top| *top + length <= end)
+        .map(|top| {
+            let (perf_number, perf_decimal) = perforation_position(top);
+            FramePosition {
+                top,
+                perf_number,
+                perf_decimal,
+                pulse: 0,
+            }
+        })
+        .collect();
+
+    info!(
+        frames = frames.len(),
+        polarity = ?found.polarity,
+        pitch = found.pitch as u32 * pitch,
+        "measured the loaded strip"
+    );
+
+    Ok(BoundaryType2 { frames })
+}
+
+/// Perforation calculations for 8Fh BoundaryInformation Type2. Inferred from full roll previews
+/// Start offset always seems to be 28 internal units for the first perf
+fn perforation_position(y: u32) -> (u16, u8) {
+    const PERF_ORIGIN: f64 = 28.0;
+    const PERF_PITCH: f64 = 4000.0 * 4.8 / 25.4;
+
+    let position = (y as f64 - PERF_ORIGIN) / PERF_PITCH;
+    let number = position.floor() as u16;
+    let decimal = ((position - number as f64) * 5.0).floor() as u8;
+
+    (number, decimal)
 }
 
 /// Where the adapter's opening sits on the sensor, and how wide it is

--- a/src/scan/thumbnail.rs
+++ b/src/scan/thumbnail.rs
@@ -20,7 +20,7 @@ use crate::{
             Capabilities,
             set_window::{ColorInterleaving, ScanKind, ScanMode},
         },
-        data::{Boundary, Rect, BoundaryType2, FramePosition},
+        data::{Boundary, Rect, BoundaryType2, FramePosition, PerfInformation},
         decode::{Image, Samples},
         window::{Flags, Window},
     },
@@ -90,6 +90,7 @@ pub fn frames_type2(
     caps: &Capabilities,
     pass: &Pass,
     samples: &[u16],
+    perf_info: &PerfInformation,
     length: u32,
     polarity: Option<Polarity>,
 ) -> Result<BoundaryType2, Error> {
@@ -111,15 +112,19 @@ pub fn frames_type2(
     let frames: Vec<FramePosition> = found
         .frames
         .iter()
-        .map(|frame| origin + frame.col as u32 * pitch)
-        .filter(|top| *top + length <= end)
-        .map(|top| {
-            let (perf_number, perf_decimal) = perforation_position(top);
-            FramePosition {
-                top,
-                perf_number,
-                perf_decimal,
-                pulse: 0,
+        .zip(perf_info.perfs.iter())
+        .filter_map(|(frame, perf)| {
+            let top = origin + frame.col as u32 * pitch;
+
+            if top + length <= end {
+                Some(FramePosition::new(
+                    caps.address.x_axis.optical_dpi,
+                    caps.address.thumbnail_resolution.start,
+                    frame.col as u32,
+                    perf.clone(),
+                ))
+            } else {
+                None
             }
         })
         .collect();

--- a/src/scan/thumbnail.rs
+++ b/src/scan/thumbnail.rs
@@ -22,7 +22,7 @@ use crate::{
         },
         data::{Boundary, Rect, BoundaryType2, FramePosition},
         decode::{Image, Samples},
-        window::Window,
+        window::{Flags, Window},
     },
 };
 use tracing::*;
@@ -176,6 +176,14 @@ pub(crate) fn windows(caps: &Capabilities) -> Result<Vec<Window>, Error> {
         )));
     }
 
+    let (thumb_size, flags) = if caps.identity.model().unwrap().name().starts_with("LS-4") ||
+                            caps.identity.model().unwrap().name().starts_with("LS-5") {
+                                (250_278, Flags::POSITIVE | Flags::AVERAGING)
+                            }
+                            else {
+                                (y.address_range.last, Flags::empty())
+                            };
+
     let (left, width) = opening(caps);
     let mut windows = window::blank(caps, &window::color_channels(caps))?;
     for w in &mut windows {
@@ -186,9 +194,10 @@ pub(crate) fn windows(caps: &Capabilities) -> Result<Vec<Window>, Error> {
         // Y starts at the axis rather than the first frame, so the leading
         // edge of the film is in the pass and can be found
         w.origin = (left, y.address_range.start);
-        w.size = (width, y.address_range.last);
+        w.size = (width, thumb_size);
         w.scanning_kind = ScanKind::THUMBNAIL;
         w.scanning_mode = ScanMode::NORMAL_QUALITY;
+        w.flags = flags;
         w.color_interleaving = ColorInterleaving::LINE_WITHOUT_DISTANCE;
     }
     Ok(windows)

--- a/src/scan/thumbnail.rs
+++ b/src/scan/thumbnail.rs
@@ -112,17 +112,16 @@ pub fn frames_type2(
     let frames: Vec<FramePosition> = found
         .frames
         .iter()
-        .zip(perf_info.perfs.iter())
-        .filter_map(|(frame, perf)| {
+        .filter_map(|frame| {
             let top = origin + frame.col as u32 * pitch;
 
             if top + length <= end {
-                Some(FramePosition::new(
+                FramePosition::new(
                     caps.address.x_axis.optical_dpi,
                     caps.address.thumbnail_resolution.start,
                     frame.col as u32,
-                    perf.clone(),
-                ))
+                    &perf_info,
+                )
             } else {
                 None
             }

--- a/src/scan/thumbnail.rs
+++ b/src/scan/thumbnail.rs
@@ -89,7 +89,7 @@ pub fn frames(
 pub fn frames_type2(
     caps: &Capabilities,
     pass: &Pass,
-    samples: &[u16],
+    samples: &Samples,
     perf_info: &PerfInformation,
     length: u32,
     polarity: Option<Polarity>,

--- a/src/scan/window.rs
+++ b/src/scan/window.rs
@@ -243,7 +243,7 @@ impl Recipe {
         let fast = caps.set_window.mode.contains(ScanMode::HIGH_SPEED);
 
         // Byte 43 is normal quality in every captured scan but the preview, and
-        // the LS-5000 does not offer high speed at all
+        // the LS-5000 does not offer high speed at all but does send HIGH_SPEED during a metering pass? huh?
         let mut mode = match native && fast {
             true => ScanMode::HIGH_SPEED,
             false => ScanMode::NORMAL_QUALITY,
@@ -272,6 +272,8 @@ impl Recipe {
             // Byte 40 carries one less than the reading count. Its low nibble
             // leaves the color ordering to the unit
             w.multiple_reading = self.samples - 1;
+
+            dbg!(&w);
         }
         Ok(windows)
     }

--- a/src/scan/window.rs
+++ b/src/scan/window.rs
@@ -272,8 +272,6 @@ impl Recipe {
             // Byte 40 carries one less than the reading count. Its low nibble
             // leaves the color ordering to the unit
             w.multiple_reading = self.samples - 1;
-
-            dbg!(&w);
         }
         Ok(windows)
     }

--- a/src/session/data.rs
+++ b/src/session/data.rs
@@ -181,6 +181,7 @@ impl Session {
 
     pub fn read_perforations(&mut self) -> Result<(), Error> {
         let result = self.read_data(data::DataType::Perforation, 0)?;
+        self.test_unit_ready(Duration::from_millis(500))?;
         Ok(())
     }
 

--- a/src/session/data.rs
+++ b/src/session/data.rs
@@ -52,8 +52,10 @@ impl Session {
         let mut fetch = |len: u32| -> Result<Vec<u8>, Error> {
             let cmd = Read::new(code, color, qualifier, len);
             let mut buf = vec![0u8; cmd.allocation_length()];
+            debug!("cdb for read {:02x} {:02x?}", code, &cmd.cdb());
             let completion = self.run(&cmd.cdb(), Data::In(&mut buf), PROBE_TIMEOUT)?;
             buf.truncate(completion.transferred);
+            debug!("recv {:02x?}", buf);
             Ok(buf)
         };
 
@@ -111,7 +113,7 @@ impl Session {
             self.addressing(kind, kind.row().write, color, "send data type")?;
 
         let cmd = Send::new(kind.row().code, color, qualifier, body.len() as u32);
-        debug!(?kind, bytes = body.len(), "send data");
+        debug!("cdb for send {:02x} {:02x?} data {:02x?}", kind.row().code, &cmd.cdb(), &body);
         self.run(&cmd.cdb(), Data::Out(body), PROBE_TIMEOUT)?;
         Ok(())
     }

--- a/src/session/data.rs
+++ b/src/session/data.rs
@@ -6,7 +6,7 @@ use crate::{
         caps::other::DataTypes,
         cdbs::{Execute, GetParameter, Read, Send, SendDiagnostic, SetParameter},
         curves::Curves,
-        data::{self, FrameTable},
+        data::{self, BoundaryType2, FrameTable, PerfInformation},
         sense::{self, Failure, Fault},
         window::Channel,
     }, transport::{Data, Sense, Status}
@@ -179,15 +179,20 @@ impl Session {
         Ok(())
     }
 
-    pub fn read_perforations(&mut self) -> Result<(), Error> {
-        let result = self.read_data(data::DataType::Perforation, 0)?;
+    pub fn read_perforations(&mut self) -> Result<(data::PerfInformation), Error> {
+        let (_, record) = self.read_record(data::DataType::Perforation, 0)?;
         self.test_unit_ready(Duration::from_millis(500))?;
-        Ok(())
+
+        let perfs = PerfInformation::from_bytes(&record).ok_or_else(|| malformed(format!("PerfInfo was {} bytes", record.len())))?;
+        Ok(perfs)
     }
 
-    pub fn read_boundaries_type2(&mut self) -> Result<(), Error> {
-        let result = self.read_data(data::DataType::Boundary2, 0)?;
-        Ok(())
+    pub fn read_boundaries_type2(&mut self) -> Result<(data::BoundaryType2), Error> {
+        let (_, record) = self.read_record(data::DataType::Boundary2, 0)?;
+
+        let bounds = BoundaryType2::from_bytes(&record).ok_or_else(|| malformed(format!("BoundaryType2 was {} bytes", record.len())))?;
+
+        Ok(bounds)
     }
 
     pub fn inquiry_c1(&mut self, alloc: u8) -> Result<Vec<u8>, Error> {

--- a/src/session/data.rs
+++ b/src/session/data.rs
@@ -7,7 +7,7 @@ use crate::{
         caps::other::DataTypes,
         cdbs::{Execute, GetParameter, Read, Send, SendDiagnostic, SetParameter},
         curves::Curves,
-        data,
+        data::{self, FrameTable},
         sense::{self, Failure, Fault},
         window::Channel,
     },
@@ -98,12 +98,12 @@ impl Session {
             Some(bit) if self.caps.features.data_types.contains(bit) => {}
             _ => return Err(refuse(format!("this unit does not offer {kind:?}"))),
         }
-        let Some(width) = kind.row().width else {
+        let Some((width, qualifier)) = kind.qualifier() else {
             return Err(refuse(format!(
-                "{kind:?} takes a width 2-11-2 does not fix"
+                "{kind:?} has no addressing qualifier"
             )));
         };
-        let qualifier = data::width_code(width).expect("2-11-2 widths are all encodable");
+
         Ok((width, qualifier, if kind.per_color() { color } else { 0 }))
     }
 
@@ -123,7 +123,9 @@ impl Session {
         let (_, record) = self.read_record(data::DataType::Boundary, 0)?;
         let boundary = data::Boundary::from_bytes(&record)
             .ok_or_else(|| malformed(format!("Boundary was {} bytes", record.len())))?;
-        self.frames = Some(boundary.clone());
+
+        self.frames = Some(FrameTable::Boundary(boundary.clone()));
+
         Ok(boundary)
     }
 
@@ -131,7 +133,30 @@ impl Session {
     ///
     /// `None` until something has read or written one
     pub fn frames(&self) -> Option<&data::Boundary> {
-        self.frames.as_ref()
+        match self.frames.as_ref() {
+            Some(FrameTable::Boundary(boundary)) => Some(boundary),
+            _ => None,
+        }
+    }
+
+    pub fn boundaries_type2(&mut self) -> Result<data::BoundaryType2, Error> {
+        let (_, record) = self.read_record(data::DataType::Boundary2, 0)?;
+        let boundary = data::BoundaryType2::from_bytes(&record)
+            .ok_or_else(|| malformed(format!("BoundaryType2 was {} bytes", record.len())))?;
+
+        self.frames = Some(FrameTable::BoundaryType2(boundary.clone()));
+
+        Ok(boundary)
+    }
+
+    /// The frame table as far as this session knows it
+    ///
+    /// `None` until something has read or written one
+    pub fn frames_type2(&self) -> Option<&data::BoundaryType2> {
+        match self.frames.as_ref() {
+            Some(FrameTable::BoundaryType2(boundary)) => Some(boundary),
+            _ => None,
+        }
     }
 
     /// Tell the unit where each frame is
@@ -142,7 +167,15 @@ impl Session {
     pub fn set_boundaries(&mut self, boundary: &data::Boundary) -> Result<(), Error> {
         let bytes = boundary.to_bytes()?;
         self.send_data(data::DataType::Boundary, 0, &bytes)?;
-        self.frames = Some(boundary.clone());
+        self.frames = Some(FrameTable::Boundary(boundary.clone()));
+        Ok(())
+    }
+
+    /// 2-11-9: alternate Type2 indexing for roll feeders
+    pub fn set_boundaries_type2(&mut self, boundary: &data::BoundaryType2) -> Result<(), Error> {
+        let bytes = boundary.to_bytes()?;
+        self.send_data(data::DataType::Boundary2, 0, &bytes)?;
+        self.frames = Some(FrameTable::BoundaryType2(boundary.clone()));
         Ok(())
     }
 

--- a/src/session/data.rs
+++ b/src/session/data.rs
@@ -2,16 +2,14 @@
 
 use super::{PROBE_TIMEOUT, Session, malformed};
 use crate::{
-    error::Error,
-    protocol::{
+    error::Error, protocol::{
         caps::other::DataTypes,
         cdbs::{Execute, GetParameter, Read, Send, SendDiagnostic, SetParameter},
         curves::Curves,
         data::{self, FrameTable},
         sense::{self, Failure, Fault},
         window::Channel,
-    },
-    transport::{Data, Sense, Status},
+    }, transport::{Data, Sense, Status}
 };
 use std::sync::Arc;
 use std::time::Duration;
@@ -177,6 +175,32 @@ impl Session {
         self.send_data(data::DataType::Boundary2, 0, &bytes)?;
         self.frames = Some(FrameTable::BoundaryType2(boundary.clone()));
         Ok(())
+    }
+
+    pub fn read_perforations(&mut self) -> Result<(), Error> {
+        let result = self.read_data(data::DataType::Perforation, 0)?;
+        Ok(())
+    }
+
+    pub fn read_boundaries_type2(&mut self) -> Result<(), Error> {
+        let result = self.read_data(data::DataType::Boundary2, 0)?;
+        Ok(())
+    }
+
+    pub fn inquiry_c1(&mut self, alloc: u8) -> Result<Vec<u8>, Error> {
+        debug!("c1 inquiry for len {}", alloc);
+        let mut res = vec![0u8; alloc as usize];
+        let cdb = [0x12, 0x01, 0xC1, 0x00, alloc, 0x80];
+        let completion = self.run(
+            &cdb,
+            Data::In(&mut res),
+            PROBE_TIMEOUT,
+        )?;
+
+        res.truncate(completion.transferred);
+
+        dbg!(&res);
+        Ok(res)
     }
 
     /// The exposure the unit measured for this channel when it started up

--- a/src/session/data.rs
+++ b/src/session/data.rs
@@ -2,14 +2,16 @@
 
 use super::{PROBE_TIMEOUT, Session, malformed};
 use crate::{
-    error::Error, protocol::{
+    error::Error,
+    protocol::{
         caps::other::DataTypes,
         cdbs::{Execute, GetParameter, Read, Send, SendDiagnostic, SetParameter},
         curves::Curves,
         data::{self, BoundaryType2, FrameTable, PerfInformation},
         sense::{self, Failure, Fault},
         window::Channel,
-    }, transport::{Data, Sense, Status}
+    },
+    transport::{Data, Sense, Status},
 };
 use std::sync::Arc;
 use std::time::Duration;
@@ -99,9 +101,7 @@ impl Session {
             _ => return Err(refuse(format!("this unit does not offer {kind:?}"))),
         }
         let Some((width, qualifier)) = kind.qualifier() else {
-            return Err(refuse(format!(
-                "{kind:?} has no addressing qualifier"
-            )));
+            return Err(refuse(format!("{kind:?} has no addressing qualifier")));
         };
 
         Ok((width, qualifier, if kind.per_color() { color } else { 0 }))
@@ -113,7 +113,12 @@ impl Session {
             self.addressing(kind, kind.row().write, color, "send data type")?;
 
         let cmd = Send::new(kind.row().code, color, qualifier, body.len() as u32);
-        debug!("cdb for send {:02x} {:02x?} data {:02x?}", kind.row().code, &cmd.cdb(), &body);
+        debug!(
+            "cdb for send {:02x} {:02x?} data {:02x?}",
+            kind.row().code,
+            &cmd.cdb(),
+            &body
+        );
         self.run(&cmd.cdb(), Data::Out(body), PROBE_TIMEOUT)?;
         Ok(())
     }
@@ -179,36 +184,21 @@ impl Session {
         Ok(())
     }
 
-    pub fn read_perforations(&mut self) -> Result<(data::PerfInformation), Error> {
+    pub fn read_perforations(&mut self) -> Result<data::PerfInformation, Error> {
         let (_, record) = self.read_record(data::DataType::Perforation, 0)?;
         self.test_unit_ready(Duration::from_millis(500))?;
 
-        let perfs = PerfInformation::from_bytes(&record).ok_or_else(|| malformed(format!("PerfInfo was {} bytes", record.len())))?;
+        let perfs = PerfInformation::from_bytes(&record)
+            .ok_or_else(|| malformed(format!("PerfInfo was {} bytes", record.len())))?;
         Ok(perfs)
     }
 
-    pub fn read_boundaries_type2(&mut self) -> Result<(data::BoundaryType2), Error> {
+    pub fn read_boundaries_type2(&mut self) -> Result<data::BoundaryType2, Error> {
         let (_, record) = self.read_record(data::DataType::Boundary2, 0)?;
 
-        let bounds = BoundaryType2::from_bytes(&record).ok_or_else(|| malformed(format!("BoundaryType2 was {} bytes", record.len())))?;
-
+        let bounds = BoundaryType2::from_bytes(&record)
+            .ok_or_else(|| malformed(format!("BoundaryType2 was {} bytes", record.len())))?;
         Ok(bounds)
-    }
-
-    pub fn inquiry_c1(&mut self, alloc: u8) -> Result<Vec<u8>, Error> {
-        debug!("c1 inquiry for len {}", alloc);
-        let mut res = vec![0u8; alloc as usize];
-        let cdb = [0x12, 0x01, 0xC1, 0x00, alloc, 0x80];
-        let completion = self.run(
-            &cdb,
-            Data::In(&mut res),
-            PROBE_TIMEOUT,
-        )?;
-
-        res.truncate(completion.transferred);
-
-        dbg!(&res);
-        Ok(res)
     }
 
     /// The exposure the unit measured for this channel when it started up

--- a/src/session/image.rs
+++ b/src/session/image.rs
@@ -48,8 +48,7 @@ impl Session {
                 Ok(completion) => {
                     debug!(
                         transferred = completion.transferred,
-                        want,
-                        "image READ completed"
+                        want, "image READ completed"
                     );
 
                     done += completion.transferred;
@@ -62,7 +61,7 @@ impl Session {
                 Err(Error::Device(fault))
                     if matches!(*fault, Fault::Rejected(Refusal::OutOfSequence, _)) =>
                 {
-                    dbg!("end of stream reached");
+                    debug!(done, "end of stream reached");
                     break;
                 }
                 // 2-11: a transfer shorter than asked for comes back as CHECK
@@ -78,7 +77,7 @@ impl Session {
                 },
                 Err(e) => {
                     debug!(error = ?e, "image READ failed");
-                    return Err(e)
+                    return Err(e);
                 }
             }
         }
@@ -95,7 +94,6 @@ impl Session {
     /// Dropping one closes the scan, whatever route the caller took out of it
     pub fn image_chunks<'a>(&'a mut self, layout: &Layout) -> Result<Chunks<'a>, Error> {
         let chunk = self.chunk_size(layout)?;
-        dbg!(layout.total_bytes());
         Ok(Chunks {
             session: self,
             layout: layout.clone(),

--- a/src/session/image.rs
+++ b/src/session/image.rs
@@ -27,6 +27,7 @@ impl Session {
         let chunk = self.chunk_size(layout)?;
         let code = DataType::Image.row().code;
         let width = layout.width_code();
+        let len = buf.as_mut().len();
 
         let mut done = 0;
         while done < buf.len() {
@@ -34,6 +35,14 @@ impl Session {
 
             let cmd = Read::new(code, 0, width, want as u32);
             let slice = &mut buf[done..done + want];
+
+            debug!(
+                cdb = ?cmd.cdb(),
+                want,
+                done,
+                left = len - done,
+                "executing image READ"
+            );
 
             match self.run(&cmd.cdb(), Data::In(slice), MOVE_TIMEOUT) {
                 Ok(completion) => {
@@ -53,6 +62,7 @@ impl Session {
                 Err(Error::Device(fault))
                     if matches!(*fault, Fault::Rejected(Refusal::OutOfSequence, _)) =>
                 {
+                    dbg!("end of stream reached");
                     break;
                 }
                 // 2-11: a transfer shorter than asked for comes back as CHECK
@@ -167,8 +177,7 @@ impl Chunks<'_> {
             return None;
         }
         if self.remaining == 0 {
-            self.closed = true;
-            self.spent = true;
+            self.drain();
             return None;
         }
 
@@ -191,7 +200,13 @@ impl Chunks<'_> {
                 None
             }
             Ok(got) => {
-                self.remaining -= got as u64;
+                let rem = self.remaining as i64 - got as i64;
+
+                if rem < 0 {
+                    self.remaining = 0;
+                } else {
+                    self.remaining = rem as u64;
+                }
                 // The unit ran out before the layout said it would
                 if got < want {
                     self.spent = true;
@@ -218,11 +233,6 @@ impl Chunks<'_> {
         let limit = self.layout.total_bytes().max(self.chunk as u64);
         let mut buf = vec![0u8; self.chunk];
         loop {
-            debug!(
-                remaining = self.remaining,
-                buf_len = buf.len(),
-                "issuing image READ from drain"
-            );
             match self.session.read_image(&self.layout.clone(), &mut buf) {
                 Ok(0) => break,
                 Ok(got) => {

--- a/src/session/image.rs
+++ b/src/session/image.rs
@@ -31,11 +31,18 @@ impl Session {
         let mut done = 0;
         while done < buf.len() {
             let want = chunk.min(buf.len() - done);
+
             let cmd = Read::new(code, 0, width, want as u32);
             let slice = &mut buf[done..done + want];
 
             match self.run(&cmd.cdb(), Data::In(slice), MOVE_TIMEOUT) {
                 Ok(completion) => {
+                    debug!(
+                        transferred = completion.transferred,
+                        want,
+                        "image READ completed"
+                    );
+
                     done += completion.transferred;
                     if completion.transferred < want {
                         break;
@@ -59,7 +66,10 @@ impl Session {
                     }
                     None => return Err(Error::Device(fault)),
                 },
-                Err(e) => return Err(e),
+                Err(e) => {
+                    debug!(error = ?e, "image READ failed");
+                    return Err(e)
+                }
             }
         }
         // Once a chunk, so hundreds of megabytes of scan is thousands of lines
@@ -157,13 +167,20 @@ impl Chunks<'_> {
             return None;
         }
         if self.remaining == 0 {
-            self.drain();
+            self.closed = true;
+            self.spent = true;
             return None;
         }
 
         let want = self.chunk.min(self.remaining as usize);
         buf.resize(want, 0);
         let layout = &self.layout;
+
+        debug!(
+            remaining = self.remaining,
+            buf_len = buf.len(),
+            "issuing image READ from fill"
+        );
         match self.session.read_image(layout, &mut buf[..want]) {
             Err(e) => {
                 self.spent = true;
@@ -201,6 +218,11 @@ impl Chunks<'_> {
         let limit = self.layout.total_bytes().max(self.chunk as u64);
         let mut buf = vec![0u8; self.chunk];
         loop {
+            debug!(
+                remaining = self.remaining,
+                buf_len = buf.len(),
+                "issuing image READ from drain"
+            );
             match self.session.read_image(&self.layout.clone(), &mut buf) {
                 Ok(0) => break,
                 Ok(got) => {

--- a/src/session/image.rs
+++ b/src/session/image.rs
@@ -95,6 +95,7 @@ impl Session {
     /// Dropping one closes the scan, whatever route the caller took out of it
     pub fn image_chunks<'a>(&'a mut self, layout: &Layout) -> Result<Chunks<'a>, Error> {
         let chunk = self.chunk_size(layout)?;
+        dbg!(layout.total_bytes());
         Ok(Chunks {
             session: self,
             layout: layout.clone(),

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -16,14 +16,9 @@ pub mod window;
 use crate::{
     error::Error,
     protocol::{
-        caps::{Capabilities, frames::Frames},
-        cdbs::{
+        caps::{Capabilities, frames::Frames}, cdbs::{
             Abort, ModeSelect, ModeSense, PageControl, ReleaseUnit, ReserveUnit, TestUnitReady,
-        },
-        curves::Curves,
-        data::{Boundary, CooperativeAction, Op, Operation},
-        mode,
-        sense::{Activity, Change, Coop, Fault, Intervention, Outcome, Refusal, interpret},
+        }, curves::Curves, data::{CooperativeAction, FrameTable, Op, Operation}, mode, model::Model, sense::{Activity, Change, Coop, Fault, Intervention, Outcome, Refusal, interpret}
     },
     transport::{self, Completion, Data, Transport},
 };
@@ -41,7 +36,8 @@ pub struct Session {
     /// What a step of a window coordinate is currently worth
     divisor: u16,
     /// The frame table that windowing uses
-    frames: Option<Boundary>,
+    frames: Option<FrameTable>,
+    frame_type_2: bool,
     /// CCD row response curves, read once in the preamble
     curves: Option<Arc<Curves>>,
     /// Whether we hold the unit, so [`Drop`] only releases what it took
@@ -89,12 +85,14 @@ impl Session {
     pub fn open(mut transport: Box<dyn Transport>) -> Result<Self, Error> {
         let caps = probe::capabilities(transport.as_mut())?;
         let divisor = caps.address.x_axis.dpi_range.last;
+        let frame_type_2 = !matches!(caps.identity.model(), Some(Model::Ls8000 | Model::Ls9000));
         let mut session = Self {
             transport,
             caps,
             divisor,
             reserved: false,
             frames: None,
+            frame_type_2,
             curves: None,
         };
         // INQUIRY answers while the unit is still initializing, so probing says
@@ -253,6 +251,11 @@ impl Session {
     /// What the scanner says it can do
     pub fn capabilities(&self) -> &Capabilities {
         &self.caps
+    }
+
+    /// Whether we use Framing Type2 or not
+    pub fn uses_frame_type_2(&self) -> bool {
+        self.frame_type_2
     }
 
     /// Re-read what the scanner says it can do

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -16,9 +16,15 @@ pub mod window;
 use crate::{
     error::Error,
     protocol::{
-        caps::{Capabilities, frames::Frames}, cdbs::{
+        caps::{Capabilities, frames::Frames},
+        cdbs::{
             Abort, ModeSelect, ModeSense, PageControl, ReleaseUnit, ReserveUnit, TestUnitReady,
-        }, curves::Curves, data::{CooperativeAction, FrameTable, Op, Operation}, mode, model::Model, sense::{Activity, Change, Coop, Fault, Intervention, Outcome, Refusal, interpret}
+        },
+        curves::Curves,
+        data::{CooperativeAction, FrameTable, Op, Operation},
+        mode,
+        model::Model,
+        sense::{Activity, Change, Coop, Fault, Intervention, Outcome, Refusal, interpret},
     },
     transport::{self, Completion, Data, Transport},
 };

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -346,12 +346,12 @@ impl Session {
         cdb: &[u8],
         mut data: Data<'_>,
         timeout: Duration,
-    ) -> Result<(Completion, Option<CooperativeAction>), Error> {
+    ) -> Result<(Completion, Vec<CooperativeAction>), Error> {
         // One budget for the command, re-issues included, rather than one each:
         // a fresh timeout per round would let 16 cooperative requests run for 16
         // times what the caller allowed
         let deadline = Instant::now() + timeout;
-        let mut cooperation = None;
+        let mut cooperations = Vec::new();
         let mut asked: Vec<(Coop, CooperativeAction)> = Vec::new();
         for _ in 0..=MAX_COOPERATION {
             // `Data::In` holds a `&mut [u8]` and so is not `Copy`. Reborrowing
@@ -363,7 +363,7 @@ impl Session {
             };
             let (completion, coop) = self.run_cooperative(cdb, payload, deadline, timeout)?;
             let Some(coop) = coop else {
-                return Ok((completion, cooperation));
+                return Ok((completion, cooperations));
             };
 
             // Dispatch on the record rather than the sense: the two specs give
@@ -385,7 +385,7 @@ impl Session {
                 });
             }
             asked.push((coop, record.clone()));
-            cooperation = Some(record);
+            cooperations.push(record);
         }
 
         Err(Error::Unsupported {

--- a/src/session/scan.rs
+++ b/src/session/scan.rs
@@ -6,10 +6,7 @@
 use super::Session;
 use crate::{
     error::Error,
-    protocol::{
-        decode::Samples, image::Layout, window::Window,
-        caps::set_window::ScanKind
-    },
+    protocol::{decode::Samples, image::Layout, window::Window},
     scan::pass::{self, Pass, Progress},
     session::window::Started,
 };

--- a/src/session/scan.rs
+++ b/src/session/scan.rs
@@ -240,7 +240,10 @@ fn read_chunks(
             None => {
                 let waited = Instant::now();
                 let buf = match empty.recv() {
-                    Ok(buf) => buf,
+                    Ok(buf) => {
+                        debug!("got empty buffer");
+                        buf
+                    }
                     Err(_) => return,
                 };
                 Timing::add(&timing.starved, waited.elapsed().as_nanos() as u64);

--- a/src/session/scan.rs
+++ b/src/session/scan.rs
@@ -6,7 +6,10 @@
 use super::Session;
 use crate::{
     error::Error,
-    protocol::{decode::Samples, image::Layout, window::Window},
+    protocol::{
+        decode::Samples, image::Layout, window::Window,
+        caps::set_window::ScanKind
+    },
     scan::pass::{self, Pass, Progress},
     session::window::Started,
 };
@@ -23,6 +26,8 @@ use tracing::*;
 
 /// How many raw chunks the reader and decoder have in flight between them
 const POOL: usize = 3;
+
+const ROLL_SCAN_THUMBNAIL_SIZE_BYTES: usize = 6_250_496; // needs to be 47x128K + 1x90112 to finish up successfully
 
 /// A chunk handed from the reader thread to the decoder, or how the stream ended
 enum Chunk {
@@ -82,8 +87,15 @@ impl Session {
         mut on: impl FnMut(Progress),
     ) -> Result<Pass, Error> {
         let started = self.start_pass(windows, timeout)?;
-        let layout = started.layout.clone();
+        let mut layout = started.layout.clone();
+
+        let is_full_thumbnail = windows[0].scanning_kind.contains(ScanKind::THUMBNAIL) && windows[0].size.1 > self.caps.address.y_axis.address_range.last;
+        if !self.caps.identity.is_mf() && is_full_thumbnail {
+            layout.override_size(ROLL_SCAN_THUMBNAIL_SIZE_BYTES);
+        };
+
         let total = layout.total_bytes();
+
         let curves = self.curves();
         let mut decoder = pass::decoder(&layout, curves.as_deref())?;
         samples.resize_for(&decoder);

--- a/src/session/scan.rs
+++ b/src/session/scan.rs
@@ -27,8 +27,6 @@ use tracing::*;
 /// How many raw chunks the reader and decoder have in flight between them
 const POOL: usize = 3;
 
-const ROLL_SCAN_THUMBNAIL_SIZE_BYTES: usize = 6_250_496; // needs to be 47x128K + 1x90112 to finish up successfully
-
 /// A chunk handed from the reader thread to the decoder, or how the stream ended
 enum Chunk {
     Data(Vec<u8>),
@@ -154,13 +152,7 @@ impl Session {
         mut on: impl FnMut(Progress),
     ) -> Result<Pass, Error> {
         let started = self.start_pass(windows, timeout)?;
-        let mut layout = started.layout.clone();
-
-        let is_full_thumbnail = windows[0].scanning_kind.contains(ScanKind::THUMBNAIL)
-            && windows[0].size.1 > self.caps.address.y_axis.address_range.last;
-        if !self.caps.identity.is_mf() && is_full_thumbnail {
-            layout.override_size(ROLL_SCAN_THUMBNAIL_SIZE_BYTES);
-        };
+        let layout = started.layout.clone();
 
         let total = layout.total_bytes();
 

--- a/src/session/scan.rs
+++ b/src/session/scan.rs
@@ -161,7 +161,7 @@ impl Session {
         let (rows, cols) = decoder.shape();
         Ok(Pass {
             layout: started.layout,
-            cooperation: started.cooperation,
+            cooperation: started.cooperations,
             complete: decoder.complete(),
             rows,
             cols,

--- a/src/session/scan.rs
+++ b/src/session/scan.rs
@@ -36,6 +36,73 @@ enum Chunk {
     Failed(Error),
 }
 
+struct TruncationState {
+    line: usize,
+    offset_in_line: usize,
+}
+
+impl TruncationState {
+    fn new() -> Self {
+        Self {
+            line: 0,
+            offset_in_line: 0,
+        }
+    }
+}
+
+fn strip_truncation(buf: &mut Vec<u8>, state: &mut TruncationState, layout: &Layout) {
+    let line_bytes = layout.bytes_per_line() as usize;
+    let (first_bytes, last_bytes) = layout.truncated_bytes_line;
+    let first_bytes = first_bytes as usize;
+    let last_bytes = last_bytes as usize;
+
+    let total_lines = layout.lines as usize;
+    let first_line = layout.truncated_lines_frame.0 as usize;
+    let last_line = total_lines - layout.truncated_lines_frame.1 as usize;
+
+    let mut read = 0;
+    let mut write = 0;
+
+    while read < buf.len() {
+        let remaining_in_line = line_bytes - state.offset_in_line;
+        let n = remaining_in_line.min(buf.len() - read);
+
+        let line = state.line;
+
+        // Is this line part of the actual image?
+        if line >= first_line && line < last_line {
+            let line_start = state.offset_in_line;
+            let line_end = state.offset_in_line + n;
+
+            // Keep only the intersection with:
+            //
+            //     [first_bytes, line_bytes - last_bytes)
+            //
+            let keep_start = line_start.max(first_bytes);
+            let keep_end = line_end.min(line_bytes - last_bytes);
+
+            if keep_start < keep_end {
+                let src_start = read + (keep_start - line_start);
+                let src_end = read + (keep_end - line_start);
+                let len = src_end - src_start;
+
+                buf.copy_within(src_start..src_end, write);
+                write += len;
+            }
+        }
+
+        read += n;
+        state.offset_in_line += n;
+
+        if state.offset_in_line == line_bytes {
+            state.offset_in_line = 0;
+            state.line += 1;
+        }
+    }
+
+    buf.truncate(write);
+}
+
 impl Session {
     /// Stage the windows and start a scan pass, returning once the data is ready
     ///
@@ -89,7 +156,8 @@ impl Session {
         let started = self.start_pass(windows, timeout)?;
         let mut layout = started.layout.clone();
 
-        let is_full_thumbnail = windows[0].scanning_kind.contains(ScanKind::THUMBNAIL) && windows[0].size.1 > self.caps.address.y_axis.address_range.last;
+        let is_full_thumbnail = windows[0].scanning_kind.contains(ScanKind::THUMBNAIL)
+            && windows[0].size.1 > self.caps.address.y_axis.address_range.last;
         if !self.caps.identity.is_mf() && is_full_thumbnail {
             layout.override_size(ROLL_SCAN_THUMBNAIL_SIZE_BYTES);
         };
@@ -103,21 +171,24 @@ impl Session {
         let timing = Timing::default();
         let mut decoding = Duration::ZERO;
         let mut idle = Duration::ZERO;
+        let mut truncation = TruncationState::new();
+        let reader_layout = layout.clone();
 
         thread::scope(|scope| {
             let (full_tx, full_rx) = mpsc::channel::<Chunk>();
             let (empty_tx, empty_rx) = mpsc::channel::<Vec<u8>>();
             let timing = &timing;
-            scope.spawn(move || read_chunks(self, &layout, &full_tx, &empty_rx, timing));
+            scope.spawn(move || read_chunks(self, &reader_layout, &full_tx, &empty_rx, timing));
 
             let mut out = Ok(());
             let mut bytes = 0u64;
+
             loop {
                 let waited = Instant::now();
                 let msg = full_rx.recv();
                 idle += waited.elapsed();
 
-                let chunk = match msg {
+                let mut chunk = match msg {
                     Ok(Chunk::Data(buf)) => buf,
                     Ok(Chunk::End) | Err(_) => break,
                     Ok(Chunk::Failed(e)) => {
@@ -126,11 +197,14 @@ impl Session {
                     }
                 };
 
+                bytes += chunk.len() as u64;
+
+                strip_truncation(&mut chunk, &mut truncation, &layout);
+
                 let pushed = Instant::now();
                 let decoded = decoder.push(&chunk, samples);
                 decoding += pushed.elapsed();
 
-                bytes += chunk.len() as u64;
                 let _ = empty_tx.send(chunk);
                 if let Err(e) = decoded {
                     out = Err(e);

--- a/src/session/window.rs
+++ b/src/session/window.rs
@@ -99,7 +99,8 @@ impl Session {
         let cmd = SetWindow::new(payload.len() as u32);
         debug!(id = window.id, "setting window");
         // setting windows is not a cooperative action
-        self.transport.execute(&cmd.cdb(), Data::Out(&payload), MOVE_TIMEOUT)?;
+        self.transport
+            .execute(&cmd.cdb(), Data::Out(&payload), MOVE_TIMEOUT)?;
 
         Ok(())
     }
@@ -136,8 +137,6 @@ impl Session {
         });
 
         let layout = Layout::new(&self.caps, windows, self.divisor, truncation)?;
-
-        dbg!(&layout);
 
         Ok(Started {
             layout,

--- a/src/session/window.rs
+++ b/src/session/window.rs
@@ -127,20 +127,21 @@ impl Session {
         // `run_handshake` reads the `DataType::Cooperation` record, sends SCAN
         // again with nothing in between, and hands the record back so the
         // caller can honor it once the image is read
-        let (_, cooperation) = self.run_handshake(&cmd.cdb(), Data::Out(&ids), MOVE_TIMEOUT)?;
-        debug!(?ids, ?cooperation, "scanning");
+        let (_, cooperations) = self.run_handshake(&cmd.cdb(), Data::Out(&ids), MOVE_TIMEOUT)?;
+        debug!(?ids, ?cooperations, "scanning");
 
-        let truncation = if let Some(CooperativeAction::Truncate(t)) = cooperation.as_ref() {
-            Some(t)
-        } else {
-            None
-        };
+        let truncation = cooperations.iter().find_map(|c| match c {
+            CooperativeAction::Truncate(t) => Some(t),
+            _ => None,
+        });
 
         let layout = Layout::new(&self.caps, windows, self.divisor, truncation)?;
 
+        dbg!(&layout);
+
         Ok(Started {
             layout,
-            cooperation,
+            cooperations,
         })
     }
 }
@@ -152,5 +153,5 @@ pub struct Started {
     pub layout: Layout,
     /// What the unit asked the host to do with the data, if anything. Reading
     /// the record is what lets the scan proceed; honoring it is the caller's
-    pub cooperation: Option<CooperativeAction>,
+    pub cooperations: Vec<CooperativeAction>,
 }

--- a/src/session/window.rs
+++ b/src/session/window.rs
@@ -98,7 +98,9 @@ impl Session {
 
         let cmd = SetWindow::new(payload.len() as u32);
         debug!(id = window.id, "setting window");
-        self.run(&cmd.cdb(), Data::Out(&payload), MOVE_TIMEOUT)?;
+        // setting windows is not a cooperative action
+        self.transport.execute(&cmd.cdb(), Data::Out(&payload), MOVE_TIMEOUT)?;
+
         Ok(())
     }
 
@@ -116,8 +118,6 @@ impl Session {
     /// once the image is read.
     pub fn scan(&mut self, windows: &[Window]) -> Result<Started, Error> {
         // Checks every rule spanning the set on the way
-        let layout = Layout::new(&self.caps, windows, self.divisor)?;
-
         let ids: Vec<u8> = windows.iter().map(|w| w.id).collect();
         let cmd = Scan::new(ids.len() as u8);
 
@@ -130,10 +130,13 @@ impl Session {
         let (_, cooperation) = self.run_handshake(&cmd.cdb(), Data::Out(&ids), MOVE_TIMEOUT)?;
         debug!(?ids, ?cooperation, "scanning");
 
-        if let Some(CooperativeAction::Truncate(truncation)) = cooperation.as_ref() {
-            // add truncated length per line to total read size. truncation.per_color to each scanline.
-            //truncation.per_color
-        }
+        let truncation = if let Some(CooperativeAction::Truncate(t)) = cooperation.as_ref() {
+            Some(t)
+        } else {
+            None
+        };
+
+        let layout = Layout::new(&self.caps, windows, self.divisor, truncation)?;
 
         Ok(Started {
             layout,

--- a/src/session/window.rs
+++ b/src/session/window.rs
@@ -121,12 +121,19 @@ impl Session {
         let ids: Vec<u8> = windows.iter().map(|w| w.id).collect();
         let cmd = Scan::new(ids.len() as u8);
 
+        debug!("scan cmd {:02x?}", &cmd.cdb());
+
         // 2-7: the unit answers, then asks what the host will owe the data.
         // `run_handshake` reads the `DataType::Cooperation` record, sends SCAN
         // again with nothing in between, and hands the record back so the
         // caller can honor it once the image is read
         let (_, cooperation) = self.run_handshake(&cmd.cdb(), Data::Out(&ids), MOVE_TIMEOUT)?;
         debug!(?ids, ?cooperation, "scanning");
+
+        if let Some(CooperativeAction::Truncate(truncation)) = cooperation.as_ref() {
+            // add truncated length per line to total read size. truncation.per_color to each scanline.
+            //truncation.per_color
+        }
 
         Ok(Started {
             layout,

--- a/src/transport/usb.rs
+++ b/src/transport/usb.rs
@@ -203,7 +203,7 @@ impl Transport for UsbTransport {
         // According to table 1-1-5-1 this will only ever be Good or CheckCondition, which is reasonable
         let status = Status::from(sb[0]);
 
-        let sense =  {
+        let sense = {
             Some(Sense {
                 key: sb[1],
                 asc: sb[2],

--- a/src/transport/usb.rs
+++ b/src/transport/usb.rs
@@ -203,7 +203,7 @@ impl Transport for UsbTransport {
         // According to table 1-1-5-1 this will only ever be Good or CheckCondition, which is reasonable
         let status = Status::from(sb[0]);
 
-        let sense = if status != Status::Good {
+        let sense =  {
             Some(Sense {
                 key: sb[1],
                 asc: sb[2],
@@ -215,8 +215,6 @@ impl Transport for UsbTransport {
                 information: None,
                 raw: sb.to_vec(),
             })
-        } else {
-            None
         };
 
         Ok(Completion {


### PR DESCRIPTION
WIP. PR adds support for strip film adapters and thumbnailing using them.

Currently a film strip is loaded and passed through a thumbnail run properly; the scanner always expects a fixed transfer size for a thumb run (47 blocks of 128k and 1 block of 90112b) which is then terminated with a sequence error.
8Eh perf info is read and returns data that looks valid, so we might be able to use that after all. 8Fh boundary data write doesn't work yet.
The actual image scan fails on geometry at the autofocus stage; somehow it's deduced that X needs to be 3946, which is the max value, but I seem to recall that's not the case in LS-5x.

I probably implemented some stuff in a less-than-optimal way as I really haven't written a lot of Rust and am still fighting the language, so feel free to poke holes in this draft to improve the code quality. It's also a bit messy as I haven't had the chance to clean it up yet, but I need a small break from this problem as it's frying my brain :D

This should solve #22 and #23, and also solves #21 but will only implement the full frame discovery when completed.