### PR TITLE
Add eject CLI command

### DIFF
--- a/src/bin/nkscan/cli.rs
+++ b/src/bin/nkscan/cli.rs
@@ -30,6 +30,15 @@ pub enum Action {
     Scan(Scan),
     /// Dump a scanner's INQUIRY pages. Reads only; nothing moves.
     Dump(Dump),
+    /// Eject the loaded film or holder
+    Eject(Eject),
+}
+
+/// Eject the loaded film or holder
+#[derive(clap::Args)]
+pub struct Eject {
+    /// The scanner to eject. Optional, will default to the first found.
+    pub device: Option<String>,
 }
 
 /// Which scanner to ask about itself

--- a/src/bin/nkscan/eject.rs
+++ b/src/bin/nkscan/eject.rs
@@ -1,0 +1,40 @@
+use anyhow::Result;
+use nkscan::{
+    device,
+    error::Error,
+    protocol::sense::Intervention,
+    session::Session,
+};
+
+use crate::cli::Eject;
+
+pub fn run(_args: Eject) -> Result<()> {
+    let device = device::list()
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("No scanner found"))?;
+
+    let mut session = Session::open(device.open()?)?;
+
+    println!("Connected to scanner");
+
+    match session.eject() {
+        Ok(true) => {
+            println!("Ejected");
+        }
+
+        Ok(false) => {
+            println!("Scanner does not support eject");
+        }
+
+        Err(Error::Media(Intervention::NoMedium)) => {
+            println!("Ejected");
+        }
+
+        Err(e) => {
+            return Err(e.into());
+        }
+    }
+
+    Ok(())
+}

--- a/src/bin/nkscan/eject.rs
+++ b/src/bin/nkscan/eject.rs
@@ -1,10 +1,5 @@
-use anyhow::{anyhow, Result};
-use nkscan::{
-    device,
-    error::Error,
-    protocol::sense::Intervention,
-    session::Session,
-};
+use anyhow::{Result, anyhow};
+use nkscan::{device, error::Error, protocol::sense::Intervention, session::Session};
 
 use crate::cli::Eject;
 

--- a/src/bin/nkscan/eject.rs
+++ b/src/bin/nkscan/eject.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use nkscan::{
     device,
     error::Error,
@@ -8,11 +8,21 @@ use nkscan::{
 
 use crate::cli::Eject;
 
-pub fn run(_args: Eject) -> Result<()> {
-    let device = device::list()
-        .into_iter()
-        .next()
-        .ok_or_else(|| anyhow::anyhow!("No scanner found"))?;
+pub fn run(args: Eject) -> Result<()> {
+    let devices = device::list();
+
+    let device = (if let Some(d) = args.device {
+        device::Selector::Location(d)
+    } else {
+        device::Selector::Only
+    })
+    .resolve(&devices)
+    .map_err(|e| {
+        let list: Vec<_> = devices.iter().map(ToString::to_string).collect();
+        anyhow!("{e}\n\nattached:\n  {}", list.join("\n  "))
+    })?;
+
+    println!("{device}");
 
     let mut session = Session::open(device.open()?)?;
 

--- a/src/bin/nkscan/main.rs
+++ b/src/bin/nkscan/main.rs
@@ -6,10 +6,10 @@ use tracing_subscriber::EnvFilter;
 
 mod cli;
 mod dump;
+mod eject;
 mod io;
 mod mono;
 mod scan;
-mod eject;
 
 // Legacy windows command prompt doesn't interpret ANSI escapes until a process opts in via SetConsoleMode.
 // Without this, coloring anything on Windows prints raw escape codes instead of color.

--- a/src/bin/nkscan/main.rs
+++ b/src/bin/nkscan/main.rs
@@ -9,6 +9,7 @@ mod dump;
 mod io;
 mod mono;
 mod scan;
+mod eject;
 
 // Legacy windows command prompt doesn't interpret ANSI escapes until a process opts in via SetConsoleMode.
 // Without this, coloring anything on Windows prints raw escape codes instead of color.
@@ -60,6 +61,7 @@ fn main() -> anyhow::Result<()> {
         }
         cli::Action::Scan(args) => scan::run(args)?,
         cli::Action::Dump(args) => dump::run(args)?,
+        cli::Action::Eject(args) => eject::run(args)?,
     }
 
     // Donezo


### PR DESCRIPTION
I found that, in some situations, the film is not ejected from the scanner automatically, so having a dedicated CLI option to manually eject it would be useful.

Adds a new **eject** CLI command to eject the film or holder from the scanner.

The command uses the existing scanner selection mechanism and Session::eject() implementation.

Tested on Windows with a physical Coolscan 5000 scanner using a SA-21 Adapter.

AI Disclosure: help by ChatGPT