### PR TITLE
Add manual scanning workflow for MA-21

### DIFF
--- a/src/bin/nkscan/scan.rs
+++ b/src/bin/nkscan/scan.rs
@@ -128,6 +128,13 @@ pub fn run(args: cli::Scan) -> anyhow::Result<()> {
             .adapter_id
             .is_some_and(|id| id > 0);
 
+    let uses_ma21 = uses_adapter
+        && session
+            .capabilities()
+            .address
+            .connected_adapter
+            .is_some_and(|id| id == 34);
+
     // Nothing can be framed before something is loaded
     wait_for_film(
         &mut session,
@@ -366,6 +373,19 @@ pub fn run(args: cli::Scan) -> anyhow::Result<()> {
         if no_eject {
             break;
         }
+
+        if uses_ma21 {
+            println!();
+            println!("Scan complete.");
+            println!("Replace or advance the film in the MA-21, then press Enter.");
+            println!("Press Ctrl-C to stop.");
+
+            let mut input = String::new();
+            std::io::stdin().read_line(&mut input)?;
+
+            continue;
+        }
+
         let ejected = session.eject()?;
         if ejected {
             info!("Ejected");


### PR DESCRIPTION
Although the automated scan when slide inserted is valid, when using a FH-3 strip holder you don't remove the holder to scan the next frame, you just slide it into the scanner. So, a manual scan is necessary.

- Add MA-21 detection using the scanner's reported addressing type
- Prompt the user to replace or advance the media before scanning the next frame

