### PR TITLE
Add standalone frame discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,6 +697,8 @@ dependencies = [
  "pyo3",
  "pyo3-stub-gen",
  "rayon",
+ "serde",
+ "serde_json",
  "thiserror",
  "tiff",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ indicatif = { version = "0.18", optional = true }
 tiff = { version = "0.11", optional = true }
 moxcms = { version = "0.9", optional = true }
 ctrlc = { version = "3", optional = true }
+serde = { version = "1", features = ["derive"], optional = true }
+serde_json = { version = "1", optional = true }
 
 
 [features]
@@ -57,6 +59,8 @@ cli = [
   "dep:tiff",
   "dep:moxcms",
   "dep:ctrlc",
+  "dep:serde",
+  "dep:serde_json",
 ]
 python = ["dep:pyo3", "dep:numpy", "dep:pyo3-stub-gen"]
 

--- a/nkscan.pyi
+++ b/nkscan.pyi
@@ -261,11 +261,8 @@ class Session:
         Send an edited set of frame boundaries to the unit as one table
         
         Call this after modifying what [`Session.discover_frames`][Self.discover_frames]
-        returned, before scanning - every rectangle becomes a frame entry, with
-        perforation registration derived per top on roll film. One round trip
-        however many frames changed. Scanning without this also works: the first
-        `scan_frame` over an unregistered top registers itself, just one table
-        send per edit rather than one overall.
+        returned, before scanning. Every rectangle becomes a frame entry, with
+        perforation registration derived per top on roll film.
         """
     def scan_frame(self, frame: tuple[builtins.int, builtins.int, builtins.int, builtins.int], dpi: typing.Optional[builtins.int] = None, samples: builtins.int = 1, superfine: builtins.bool = False, infrared: builtins.bool = False, clean: builtins.bool = False, lock_white_balance: builtins.bool = True, exposures: typing.Optional[typing.Mapping[builtins.str, builtins.int]] = None, progress: typing.Optional[typing.Any] = None) -> ScanResult:
         r"""

--- a/nkscan.pyi
+++ b/nkscan.pyi
@@ -256,6 +256,17 @@ class Session:
         works the same as a detected one, just slower if the stage has to home
         first to reach it
         """
+    def set_frames(self, frames: typing.Sequence[tuple[builtins.int, builtins.int, builtins.int, builtins.int]]) -> None:
+        r"""
+        Send an edited set of frame boundaries to the unit as one table
+        
+        Call this after modifying what [`Session.discover_frames`][Self.discover_frames]
+        returned, before scanning - every rectangle becomes a frame entry, with
+        perforation registration derived per top on roll film. One round trip
+        however many frames changed. Scanning without this also works: the first
+        `scan_frame` over an unregistered top registers itself, just one table
+        send per edit rather than one overall.
+        """
     def scan_frame(self, frame: tuple[builtins.int, builtins.int, builtins.int, builtins.int], dpi: typing.Optional[builtins.int] = None, samples: builtins.int = 1, superfine: builtins.bool = False, infrared: builtins.bool = False, clean: builtins.bool = False, lock_white_balance: builtins.bool = True, exposures: typing.Optional[typing.Mapping[builtins.str, builtins.int]] = None, progress: typing.Optional[typing.Any] = None) -> ScanResult:
         r"""
         Focus, meter, take the pass over `frame`, and optionally clean it

--- a/src/bin/nkscan/cli.rs
+++ b/src/bin/nkscan/cli.rs
@@ -31,6 +31,8 @@ pub enum Action {
     List,
     /// Perform a scan. Defaults to batch scanning with sensible defaults.
     Scan(Scan),
+    /// Find the frames on what is loaded and write them out for editing, without scanning. Pairs with `scan --frames-file`
+    Discover(Discover),
     /// Dump a scanner's INQUIRY pages. Reads only; nothing moves.
     Dump(Dump),
     /// Eject the loaded film or holder
@@ -42,6 +44,33 @@ pub enum Action {
 pub struct Eject {
     /// The scanner to eject. Optional, will default to the first found.
     pub device: Option<String>,
+}
+
+/// Find the frames without scanning them
+#[derive(clap::Args)]
+pub struct Discover {
+    /// The scanner to connect to. Optional, will default to the first found.
+    pub device: Option<String>,
+
+    /// Where to write, as a path prefix. The boundaries go to <basename>_<n>_frames.json
+    #[arg(long, default_value = "scan")]
+    pub basename: PathBuf,
+
+    /// Film format. One of: 135, half, IX240, 16, 645, 66, 67, 68, 69, or a custom frame length in mm. Defaults to what the holder reports (if any).
+    #[arg(long, value_parser = FilmFormat::from_str)]
+    pub format: Option<FilmFormat>,
+
+    /// Film type, which says which way detection reads the gaps between frames
+    #[arg(long, value_enum, default_value_t = FilmType::Negative)]
+    pub film: FilmType,
+
+    /// Keep the framing thumbnail as <basename>_<n>_thumbnail.tiff, on units that support this
+    #[arg(long)]
+    pub thumbnail: bool,
+
+    /// Eject when done. Without this the film stays loaded, ready for `nkscan scan --frames-file`
+    #[arg(long)]
+    pub eject: bool,
 }
 
 /// Which scanner to ask about itself
@@ -91,6 +120,12 @@ pub struct Scan {
     /// Naming any stops after one holder rather than batching.
     #[arg(long, value_delimiter = ',')]
     pub frames: Vec<usize>,
+
+    /// Scan the frames listed in a boundaries file from `nkscan discover`,
+    /// instead of running discovery here. Edit that file's `frames` array to
+    /// move, shrink or drop detections before handing it back
+    #[arg(long, value_name = "JSON", conflicts_with = "format")]
+    pub frames_file: Option<PathBuf>,
 
     /// Include the IR pass
     #[arg(long)]

--- a/src/bin/nkscan/common.rs
+++ b/src/bin/nkscan/common.rs
@@ -6,11 +6,7 @@
 use crate::{cancel, progress};
 use anyhow::Result;
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
-use nkscan::{
-    error::Error,
-    scan::pass::Progress,
-    session::Session,
-};
+use nkscan::{error::Error, scan::pass::Progress, session::Session};
 
 /// Moving a pass's progress onto a bar
 pub trait Report {
@@ -25,7 +21,7 @@ impl Report for ProgressBar {
         self.set_position(progress.bytes);
     }
 }
-use std::{borrow::Cow, io::Write, io::IsTerminal, time::Duration};
+use std::{borrow::Cow, io::IsTerminal, io::Write, time::Duration};
 use tracing::*;
 
 /// How often to ask whether a holder has gone in

--- a/src/bin/nkscan/common.rs
+++ b/src/bin/nkscan/common.rs
@@ -1,0 +1,193 @@
+//! Film handling and progress helpers shared by the scanning commands
+//!
+//! Lifted out of `scan` so `discover` can drive the same load-and-wait flow
+//! against the same prompts, and draw its pass on the same bars.
+
+use crate::{cancel, progress};
+use anyhow::Result;
+use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
+use nkscan::{
+    error::Error,
+    scan::pass::Progress,
+    session::Session,
+};
+
+/// Moving a pass's progress onto a bar
+pub trait Report {
+    fn report(&self, progress: Progress);
+}
+
+impl Report for ProgressBar {
+    fn report(&self, progress: Progress) {
+        // The layout's own total, which the cooperative modes can make wrong, so
+        // it is set every time rather than once
+        self.set_length(progress.total);
+        self.set_position(progress.bytes);
+    }
+}
+use std::{borrow::Cow, io::Write, io::IsTerminal, time::Duration};
+use tracing::*;
+
+/// How often to ask whether a holder has gone in
+pub const HOLDER_POLL: Duration = Duration::from_millis(500);
+
+/// How often the spinner moves while that is going on
+const SPINNER_TICK: Duration = Duration::from_millis(120);
+
+/// Whether there is film to scan
+///
+/// A feeder or a cartridge keeps its film behind the gate, so nothing reads as
+/// loaded until the unit is told to take some in. `take_in` is whether it may:
+/// false once a medium has been scanned and ejected, where loading again would
+/// only bring the same film back
+pub fn ready(session: &mut Session, take_in: bool) -> Result<bool, Error> {
+    if session.media_loaded()? {
+        return Ok(true);
+    }
+    if !take_in || !session.load()? {
+        return Ok(false);
+    }
+    // The address page now describes the medium that came in
+    session.refresh()?;
+    session.media_loaded()
+}
+
+/// The same, counting anything the operator can put right as "not yet": an open
+/// door is what the prompt is for
+fn waiting(session: &mut Session, take_in: bool) -> Result<bool, Error> {
+    match ready(session, take_in) {
+        Err(Error::Media(condition)) => {
+            debug!(%condition, "waiting on the operator");
+            Ok(false)
+        }
+        other => other,
+    }
+}
+
+/// [`Session::refresh`], tolerating the medium-not-present it can itself hit:
+/// a strip feeder's gate sits empty between strips, and that is the state this
+/// is called from a loop to wait out, not a failure of the refresh
+fn refresh_while_empty(session: &mut Session) -> Result<(), Error> {
+    match session.refresh() {
+        Ok(()) | Err(Error::Media(_)) => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+/// Wait until a holder is loaded, then put the unit in a state to scan from
+pub fn wait_for_film(session: &mut Session, prompt: &str, take_in: bool) -> Result<()> {
+    // An eject leaves what we know about the holder behind, so ask again before
+    // believing anything is in there
+    refresh_while_empty(session)?;
+
+    if !waiting(session, take_in)? {
+        // The spinner is the affordance on a terminal, and hidden anywhere else, so the log says it too
+        info!("{prompt}");
+        let spinner = ProgressBar::with_draw_target(None, ProgressDrawTarget::hidden());
+        spinner.set_style(ProgressStyle::default_spinner());
+        spinner.set_message(format!("{prompt}. Ctrl-c to stop"));
+        let spinner = progress::add(spinner);
+        spinner.enable_steady_tick(SPINNER_TICK);
+        loop {
+            // Nothing is moving while this waits, so stopping here is always safe
+            if cancel::requested() {
+                return Err(Error::Cancelled.into());
+            }
+            std::thread::sleep(HOLDER_POLL);
+            refresh_while_empty(session)?;
+            // Retrying the load is what picks up a supply that was refilled
+            if waiting(session, take_in)? {
+                progress::done(spinner);
+                break;
+            }
+        }
+    }
+    info!("film loaded");
+    session.stage()?;
+    Ok(())
+}
+
+/// Ask the operator for something and wait for them, answering whether anyone
+/// was there to answer. Polls for Ctrl-c on a background reader thread, same
+/// as every other wait
+pub fn confirm(prompt: &str) -> Result<bool> {
+    eprintln!("{prompt}. Ctrl-c to stop");
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let mut line = String::new();
+        let _ = tx.send(std::io::stdin().read_line(&mut line).map(|n| n > 0));
+    });
+    loop {
+        if cancel::requested() {
+            return Err(Error::Cancelled.into());
+        }
+        match rx.recv_timeout(HOLDER_POLL) {
+            Ok(answered) => {
+                // The Enter that answered this has been echoed as a line of its
+                // own, so step back over it rather than leaving a blank line
+                let mut err = std::io::stderr().lock();
+                if err.is_terminal() {
+                    let _ = err.write_all(b"\x1b[1A\x1b[2K");
+                }
+                return Ok(answered?);
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => return Ok(false),
+        }
+    }
+}
+
+/// A bar for one pass
+///
+/// The length is not known until the first chunk arrives, so it starts empty
+/// and learns. Hidden by indicatif when stderr is not a terminal, and drawn no
+/// more than 20 times a second, which is what keeps the callback off the
+/// scanner's back
+pub fn pass_bar(label: impl Into<Cow<'static, str>>, total: u64) -> ProgressBar {
+    // A bar built the usual way draws straight to stderr, so styling and naming
+    // it here would leave that first line behind the moment `add` moves it onto
+    // the shared draw target. Built hidden, it draws nothing until it is added
+    let bar = ProgressBar::with_draw_target(Some(total), ProgressDrawTarget::hidden());
+    bar.set_style(
+        ProgressStyle::with_template(
+            "{msg:<9} [{bar:30}] {bytes}/{total_bytes}  {bytes_per_sec}  eta {eta}",
+        )
+        .expect("a template of ours")
+        .progress_chars("=> "),
+    );
+    bar.set_message(label.into());
+    progress::add(bar)
+}
+
+/// A pass bar that learns its length from the first chunk
+///
+/// Discovery passes do not know how long they are until data starts arriving,
+/// so the bar stays hidden until then rather than drawing `0 B/0 B`. One of
+/// these per pass; [`PassBar::done`] hands it back to the shared draw target.
+pub struct PassBar {
+    label: &'static str,
+    bar: Option<ProgressBar>,
+}
+
+impl PassBar {
+    pub fn new(label: &'static str) -> Self {
+        Self { label, bar: None }
+    }
+
+    /// Report one chunk onto the bar, creating the bar if this was the first
+    pub fn update(&mut self, p: Progress) {
+        if self.bar.is_none() && p.total > 0 {
+            self.bar = Some(pass_bar(self.label, p.total));
+        }
+        if let Some(bar) = &self.bar {
+            bar.report(p);
+        }
+    }
+
+    /// Retire the bar, whether or not any data ever arrived
+    pub fn done(self) {
+        if let Some(bar) = self.bar {
+            progress::done(bar);
+        }
+    }
+}

--- a/src/bin/nkscan/discover.rs
+++ b/src/bin/nkscan/discover.rs
@@ -9,13 +9,7 @@
 
 use crate::{cancel, cli, common, frames, io};
 use anyhow::Result;
-use nkscan::{
-    device,
-    error::Error,
-    protocol::decode::Samples,
-    scan::framing,
-    session::Session,
-};
+use nkscan::{device, error::Error, protocol::decode::Samples, scan::framing, session::Session};
 use std::{ops::ControlFlow, path::PathBuf};
 use tracing::*;
 
@@ -53,11 +47,7 @@ fn discover_cancellable(session: &mut Session, args: &cli::Discover) -> Result<(
 
     let product = session.capabilities().identity.product.clone();
 
-    common::wait_for_film(
-        session,
-        "load a film strip",
-        true,
-    )?;
+    common::wait_for_film(session, "load a film strip", true)?;
 
     // One buffer for the thumbnail pass, as the scan command keeps per strip
     let mut samples = Samples::default();
@@ -83,21 +73,14 @@ fn discover_cancellable(session: &mut Session, args: &cli::Discover) -> Result<(
         info!("wrote {}", path.display());
     }
 
-    let path = PathBuf::from(format!(
-        "{}_{first}_frames.json",
-        basename.display()
-    ));
+    let path = PathBuf::from(format!("{}_{first}_frames.json", basename.display()));
     let saved = frames::from_discovery(
         Some(product.to_string()),
         &format!("{mechanism:?}"),
         &discovery.frames,
     );
     frames::save(&path, &saved)?;
-    info!(
-        frames = discovery.frames.len(),
-        "{}",
-        path.display()
-    );
+    info!(frames = discovery.frames.len(), "{}", path.display());
 
     if *eject {
         let ejected = session.eject()?;
@@ -109,4 +92,3 @@ fn discover_cancellable(session: &mut Session, args: &cli::Discover) -> Result<(
     }
     Ok(())
 }
-

--- a/src/bin/nkscan/discover.rs
+++ b/src/bin/nkscan/discover.rs
@@ -90,7 +90,6 @@ fn discover_cancellable(session: &mut Session, args: &cli::Discover) -> Result<(
     let saved = frames::from_discovery(
         Some(product.to_string()),
         &format!("{mechanism:?}"),
-        &discovery.table,
         &discovery.frames,
     );
     frames::save(&path, &saved)?;

--- a/src/bin/nkscan/discover.rs
+++ b/src/bin/nkscan/discover.rs
@@ -1,0 +1,113 @@
+//! Finding the frames without scanning them
+//!
+//! Half of a two-step workflow: `discover` runs whatever framing pass the unit
+//! needs, writes the detected boundaries to `<basename>_<n>_frames.json`, and
+//! leaves the film where it is. The operator edits the rectangles in that file.
+//!
+//! Nothing here ejects by default, because the point is to scan the same strip
+//! afterwards.
+
+use crate::{cancel, cli, common, frames, io};
+use anyhow::Result;
+use nkscan::{
+    device,
+    error::Error,
+    protocol::decode::Samples,
+    scan::framing,
+    session::Session,
+};
+use std::{ops::ControlFlow, path::PathBuf};
+use tracing::*;
+
+/// Find the frames on what is loaded, and write them out
+pub fn run(args: cli::Discover) -> Result<()> {
+    let devices = device::list();
+    let device = (if let Some(d) = args.device.clone() {
+        device::Selector::Location(d)
+    } else {
+        device::Selector::Only
+    })
+    .resolve(&devices)?;
+
+    let mut session = Session::open(device.open()?)?;
+    info!("connected to scanner");
+
+    match discover_cancellable(&mut session, &args) {
+        Err(e) if matches!(e.downcast_ref::<Error>(), Some(Error::Cancelled)) => {
+            info!("cancelled");
+            Ok(())
+        }
+        other => other,
+    }
+}
+
+fn discover_cancellable(session: &mut Session, args: &cli::Discover) -> Result<()> {
+    let cli::Discover {
+        device: _,
+        basename,
+        format,
+        film,
+        thumbnail: save_thumbnail,
+        eject,
+    } = args;
+
+    let product = session.capabilities().identity.product.clone();
+
+    common::wait_for_film(
+        session,
+        "load a film strip",
+        true,
+    )?;
+
+    // One buffer for the thumbnail pass, as the scan command keeps per strip
+    let mut samples = Samples::default();
+
+    // Numbered like everything else through this basename, so a re-discover of
+    // the same strip overwrites its own output rather than anyone else's
+    let first = io::next_free(basename);
+
+    let mechanism = framing::Framing::choose(session.capabilities());
+    let mut bar = common::PassBar::new("thumbnail");
+    let discovery = framing::discover_with(session, *format, (*film).into(), &mut samples, |p| {
+        bar.update(p);
+        if cancel::requested() {
+            ControlFlow::Break(())
+        } else {
+            ControlFlow::Continue(())
+        }
+    })?;
+    bar.done();
+
+    if *save_thumbnail && let Some(pass) = &discovery.thumbnail {
+        let path = io::write_thumbnail(basename, first, &samples, pass)?;
+        info!("wrote {}", path.display());
+    }
+
+    let path = PathBuf::from(format!(
+        "{}_{first}_frames.json",
+        basename.display()
+    ));
+    let saved = frames::from_discovery(
+        Some(product.to_string()),
+        &format!("{mechanism:?}"),
+        &discovery.table,
+        &discovery.frames,
+    );
+    frames::save(&path, &saved)?;
+    info!(
+        frames = discovery.frames.len(),
+        "{}",
+        path.display()
+    );
+
+    if *eject {
+        let ejected = session.eject()?;
+        if ejected {
+            info!("ejected");
+        }
+    } else {
+        info!("film left loaded for `nkscan scan --frames-file`");
+    }
+    Ok(())
+}
+

--- a/src/bin/nkscan/frames.rs
+++ b/src/bin/nkscan/frames.rs
@@ -1,34 +1,19 @@
 //! The detected frame boundaries, saved to disk and read back
 
 use anyhow::{Context, Result};
-use nkscan::protocol::data::{FramePosition, FrameTable, Rect};
+use nkscan::protocol::data::Rect;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
-/// Bump when the shape changes so an old file says so rather than misreads
-const VERSION: u32 = 1;
-
 #[derive(Serialize, Deserialize)]
 pub struct Saved {
-    pub version: u32,
     /// Product string of the unit this came from. A mismatch is a warning,
     /// not a refusal: the coordinates may still be right
     pub product: Option<String>,
     /// Which framing mechanism produced this, as information only
     pub mechanism: String,
-    pub table: TableDto,
     /// The frames a scan will take, in scan order. This is the part to edit
     pub frames: Vec<RectDto>,
-}
-
-#[derive(Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
-pub enum TableDto {
-    /// What was sent as `DataType::Boundary`
-    Boundary { frames: Vec<RectDto> },
-    /// What was sent as `DataType::BoundaryType2` (perforation-indexed)
-    #[serde(rename = "boundary_type2")]
-    BoundaryType2 { frames: Vec<FramePosDto> },
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
@@ -51,56 +36,15 @@ impl From<RectDto> for Rect {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, Debug)]
-pub struct FramePosDto {
-    pub top: u32,
-    pub perf_number: u16,
-    pub perf_decimal: u8,
-    pub pulse_number: u8,
-}
-
-impl From<FramePosition> for FramePosDto {
-    fn from(f: FramePosition) -> Self {
-        Self {
-            top: f.top,
-            perf_number: f.perf_number,
-            perf_decimal: f.perf_decimal,
-            pulse_number: f.pulse_number,
-        }
-    }
-}
-
-impl From<FramePosDto> for FramePosition {
-    fn from(f: FramePosDto) -> Self {
-        FramePosition {
-            top: f.top,
-            perf_number: f.perf_number,
-            perf_decimal: f.perf_decimal,
-            pulse_number: f.pulse_number,
-        }
-    }
-}
-
-/// Pack a discovery result's table and frames for writing
+/// Pack a discovery result's frames for writing
 pub fn from_discovery(
     product: Option<String>,
     mechanism: &str,
-    table: &FrameTable,
     frames: &[Rect],
 ) -> Saved {
-    let table = match table {
-        FrameTable::Boundary(b) => TableDto::Boundary {
-            frames: b.frames.iter().map(|&r| r.into()).collect(),
-        },
-        FrameTable::BoundaryType2(t) => TableDto::BoundaryType2 {
-            frames: t.frames.iter().map(|&f| f.into()).collect(),
-        },
-    };
     Saved {
-        version: VERSION,
         product,
         mechanism: mechanism.to_string(),
-        table,
         frames: frames.iter().map(|&r| r.into()).collect(),
     }
 }
@@ -124,13 +68,5 @@ pub fn load(path: &Path) -> Result<Saved> {
         .with_context(|| format!("reading {}", path.display()))?;
     let saved: Saved =
         serde_json::from_str(&text).context("parsing the frame boundaries file")?;
-    if saved.version != VERSION {
-        anyhow::bail!(
-            "{} is a v{} boundaries file, but this build reads v{}",
-            path.display(),
-            saved.version,
-            VERSION
-        );
-    }
     Ok(saved)
 }

--- a/src/bin/nkscan/frames.rs
+++ b/src/bin/nkscan/frames.rs
@@ -26,22 +26,28 @@ pub struct RectDto {
 
 impl From<Rect> for RectDto {
     fn from(r: Rect) -> Self {
-        Self { top: r.top, left: r.left, bottom: r.bottom, right: r.right }
+        Self {
+            top: r.top,
+            left: r.left,
+            bottom: r.bottom,
+            right: r.right,
+        }
     }
 }
 
 impl From<RectDto> for Rect {
     fn from(r: RectDto) -> Self {
-        Rect { top: r.top, left: r.left, bottom: r.bottom, right: r.right }
+        Rect {
+            top: r.top,
+            left: r.left,
+            bottom: r.bottom,
+            right: r.right,
+        }
     }
 }
 
 /// Pack a discovery result's frames for writing
-pub fn from_discovery(
-    product: Option<String>,
-    mechanism: &str,
-    frames: &[Rect],
-) -> Saved {
+pub fn from_discovery(product: Option<String>, mechanism: &str, frames: &[Rect]) -> Saved {
     Saved {
         product,
         mechanism: mechanism.to_string(),
@@ -58,15 +64,13 @@ impl Saved {
 
 pub fn save(path: &Path, saved: &Saved) -> Result<()> {
     let json = serde_json::to_string_pretty(saved).context("serializing the frame boundaries")?;
-    std::fs::write(path, json + "\n")
-        .with_context(|| format!("writing {}", path.display()))?;
+    std::fs::write(path, json + "\n").with_context(|| format!("writing {}", path.display()))?;
     Ok(())
 }
 
 pub fn load(path: &Path) -> Result<Saved> {
-    let text = std::fs::read_to_string(path)
-        .with_context(|| format!("reading {}", path.display()))?;
-    let saved: Saved =
-        serde_json::from_str(&text).context("parsing the frame boundaries file")?;
+    let text =
+        std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    let saved: Saved = serde_json::from_str(&text).context("parsing the frame boundaries file")?;
     Ok(saved)
 }

--- a/src/bin/nkscan/frames.rs
+++ b/src/bin/nkscan/frames.rs
@@ -1,0 +1,136 @@
+//! The detected frame boundaries, saved to disk and read back
+
+use anyhow::{Context, Result};
+use nkscan::protocol::data::{FramePosition, FrameTable, Rect};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+/// Bump when the shape changes so an old file says so rather than misreads
+const VERSION: u32 = 1;
+
+#[derive(Serialize, Deserialize)]
+pub struct Saved {
+    pub version: u32,
+    /// Product string of the unit this came from. A mismatch is a warning,
+    /// not a refusal: the coordinates may still be right
+    pub product: Option<String>,
+    /// Which framing mechanism produced this, as information only
+    pub mechanism: String,
+    pub table: TableDto,
+    /// The frames a scan will take, in scan order. This is the part to edit
+    pub frames: Vec<RectDto>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TableDto {
+    /// What was sent as `DataType::Boundary`
+    Boundary { frames: Vec<RectDto> },
+    /// What was sent as `DataType::BoundaryType2` (perforation-indexed)
+    #[serde(rename = "boundary_type2")]
+    BoundaryType2 { frames: Vec<FramePosDto> },
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RectDto {
+    pub top: u32,
+    pub left: u32,
+    pub bottom: u32,
+    pub right: u32,
+}
+
+impl From<Rect> for RectDto {
+    fn from(r: Rect) -> Self {
+        Self { top: r.top, left: r.left, bottom: r.bottom, right: r.right }
+    }
+}
+
+impl From<RectDto> for Rect {
+    fn from(r: RectDto) -> Self {
+        Rect { top: r.top, left: r.left, bottom: r.bottom, right: r.right }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy, Debug)]
+pub struct FramePosDto {
+    pub top: u32,
+    pub perf_number: u16,
+    pub perf_decimal: u8,
+    pub pulse_number: u8,
+}
+
+impl From<FramePosition> for FramePosDto {
+    fn from(f: FramePosition) -> Self {
+        Self {
+            top: f.top,
+            perf_number: f.perf_number,
+            perf_decimal: f.perf_decimal,
+            pulse_number: f.pulse_number,
+        }
+    }
+}
+
+impl From<FramePosDto> for FramePosition {
+    fn from(f: FramePosDto) -> Self {
+        FramePosition {
+            top: f.top,
+            perf_number: f.perf_number,
+            perf_decimal: f.perf_decimal,
+            pulse_number: f.pulse_number,
+        }
+    }
+}
+
+/// Pack a discovery result's table and frames for writing
+pub fn from_discovery(
+    product: Option<String>,
+    mechanism: &str,
+    table: &FrameTable,
+    frames: &[Rect],
+) -> Saved {
+    let table = match table {
+        FrameTable::Boundary(b) => TableDto::Boundary {
+            frames: b.frames.iter().map(|&r| r.into()).collect(),
+        },
+        FrameTable::BoundaryType2(t) => TableDto::BoundaryType2 {
+            frames: t.frames.iter().map(|&f| f.into()).collect(),
+        },
+    };
+    Saved {
+        version: VERSION,
+        product,
+        mechanism: mechanism.to_string(),
+        table,
+        frames: frames.iter().map(|&r| r.into()).collect(),
+    }
+}
+
+impl Saved {
+    /// The frames a scan will take, in scan order
+    pub fn frames(&self) -> Vec<Rect> {
+        self.frames.iter().map(|&r| r.into()).collect()
+    }
+}
+
+pub fn save(path: &Path, saved: &Saved) -> Result<()> {
+    let json = serde_json::to_string_pretty(saved).context("serializing the frame boundaries")?;
+    std::fs::write(path, json + "\n")
+        .with_context(|| format!("writing {}", path.display()))?;
+    Ok(())
+}
+
+pub fn load(path: &Path) -> Result<Saved> {
+    let text = std::fs::read_to_string(path)
+        .with_context(|| format!("reading {}", path.display()))?;
+    let saved: Saved =
+        serde_json::from_str(&text).context("parsing the frame boundaries file")?;
+    if saved.version != VERSION {
+        anyhow::bail!(
+            "{} is a v{} boundaries file, but this build reads v{}",
+            path.display(),
+            saved.version,
+            VERSION
+        );
+    }
+    Ok(saved)
+}

--- a/src/bin/nkscan/main.rs
+++ b/src/bin/nkscan/main.rs
@@ -6,8 +6,11 @@ use tracing_subscriber::EnvFilter;
 
 mod cancel;
 mod cli;
+mod common;
+mod discover;
 mod dump;
 mod eject;
+mod frames;
 mod io;
 mod mono;
 mod progress;
@@ -70,6 +73,11 @@ fn main() -> anyhow::Result<()> {
         cli::Action::Scan(args) => {
             let outcome = scan::run(args);
             // A pass that ended early still has its bar drawn
+            progress::clear();
+            outcome?
+        }
+        cli::Action::Discover(args) => {
+            let outcome = discover::run(args);
             progress::clear();
             outcome?
         }

--- a/src/bin/nkscan/scan.rs
+++ b/src/bin/nkscan/scan.rs
@@ -4,8 +4,7 @@
 //! take the pass. What that costs is a stage move each way, so it is done once
 //! per frame rather than once per channel.
 
-use crate::{cancel, cli, common,
-            common::Report, frames, io};
+use crate::{cancel, cli, common, common::Report, frames, io};
 use anyhow::{anyhow, bail};
 use indicatif::ProgressBar;
 use nkscan::{
@@ -231,7 +230,11 @@ fn run_cancellable(session: &mut Session, args: cli::Scan) -> anyhow::Result<()>
                 "boundaries from {}",
                 path.display()
             );
-            framing::Discovery { table, frames: saved.frames(), thumbnail: None }
+            framing::Discovery {
+                table,
+                frames: saved.frames(),
+                thumbnail: None,
+            }
         } else {
             // Only two of the four mechanisms take a pass to find the frames; the
             // others read them off a page and would leave a bar claiming a pass was
@@ -311,7 +314,8 @@ fn run_cancellable(session: &mut Session, args: cli::Scan) -> anyhow::Result<()>
                             // a length keeps that line off the screen, and names
                             // the bar for the pass it is rather than renaming it
                             if meter_bar.is_none() && p.total > 0 {
-                                meter_bar = Some(common::pass_bar(format!("meter {pass}"), p.total));
+                                meter_bar =
+                                    Some(common::pass_bar(format!("meter {pass}"), p.total));
                                 shown = pass;
                             }
                             if let Some(bar) = &meter_bar {
@@ -328,7 +332,8 @@ fn run_cancellable(session: &mut Session, args: cli::Scan) -> anyhow::Result<()>
                                 crate::progress::done(bar);
                             }
                             if scan_bar.is_none() && p.total > 0 {
-                                scan_bar = Some(common::pass_bar(format!("frame {}", n + 1), p.total));
+                                scan_bar =
+                                    Some(common::pass_bar(format!("frame {}", n + 1), p.total));
                             }
                             if let Some(bar) = &scan_bar {
                                 bar.report(p);

--- a/src/bin/nkscan/scan.rs
+++ b/src/bin/nkscan/scan.rs
@@ -4,9 +4,10 @@
 //! take the pass. What that costs is a stage move each way, so it is done once
 //! per frame rather than once per channel.
 
-use crate::{cancel, cli, io};
+use crate::{cancel, cli, common,
+            common::Report, frames, io};
 use anyhow::{anyhow, bail};
-use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
+use indicatif::ProgressBar;
 use nkscan::{
     device,
     error::Error,
@@ -16,29 +17,17 @@ use nkscan::{
         frame::{self, Phase},
         framing::{self, Framing},
         meter::Metering,
-        pass::Progress,
         profile,
         window::Recipe,
     },
     session::Session,
 };
-use std::{
-    borrow::Cow,
-    io::{IsTerminal, Write},
-    ops::ControlFlow,
-    time::Duration,
-};
+use std::{ops::ControlFlow, time::Duration};
 use tracing::*;
-
-/// How often to ask whether a holder has gone in
-const HOLDER_POLL: Duration = Duration::from_millis(500);
 
 /// Long enough to tell a unit that is still answering from one that is gone,
 /// and no longer: this only gates whether the eject below is worth attempting
 const STILL_THERE: Duration = Duration::from_secs(5);
-
-/// How often the spinner moves while that is going on
-const SPINNER_TICK: Duration = Duration::from_millis(120);
 
 /// Scan what the flags ask for
 pub fn run(args: cli::Scan) -> anyhow::Result<()> {
@@ -122,6 +111,7 @@ fn run_cancellable(session: &mut Session, args: cli::Scan) -> anyhow::Result<()>
         ir,
         clean,
         no_eject,
+        frames_file,
         thumbnail: save_thumbnail,
         format,
         film,
@@ -186,7 +176,7 @@ fn run_cancellable(session: &mut Session, args: cli::Scan) -> anyhow::Result<()>
             .is_some_and(|id| id > 0);
 
     // Nothing can be framed before something is loaded
-    wait_for_film(
+    common::wait_for_film(
         session,
         &format!(
             "load a film {}",
@@ -217,28 +207,49 @@ fn run_cancellable(session: &mut Session, args: cli::Scan) -> anyhow::Result<()>
         // discovery because the thumbnail is numbered with it
         let first = io::next_free(&basename);
 
-        // Only two of the four mechanisms take a pass to find the frames; the
-        // others read them off a page and would leave a bar claiming a pass was
-        // running. Made on the first report with a length for the same reason
-        // the metering bars are
-        let takes_pass = matches!(framing, Framing::Thumbnail | Framing::Perforation);
-        let mut bar: Option<ProgressBar> = None;
-        let discovery = framing::discover_with(session, format, film.into(), &mut samples, |p| {
-            if takes_pass && bar.is_none() && p.total > 0 {
-                bar = Some(pass_bar("thumbnail", p.total));
+        // Boundaries from a previous `discover` run, edited or not: send the
+        // table back so this fresh session knows the frame lengths again, then
+        // scan exactly what the file says. The film is already in the gate, so
+        // this strip is the one the boundaries describe
+        let discovery = if let Some(path) = &frames_file {
+            let saved = frames::load(path)?;
+            if let Some(product) = &saved.product
+                && product != &session.capabilities().identity.product
+            {
+                warn!(
+                    saved = product,
+                    scanner = session.capabilities().identity.product,
+                    "boundaries were made on a different scanner model"
+                );
             }
-            if let Some(bar) = &bar {
-                bar.report(p);
-            }
-            if cancel::requested() {
-                ControlFlow::Break(())
-            } else {
-                ControlFlow::Continue(())
-            }
-        })?;
-        if let Some(bar) = bar {
-            crate::progress::done(bar);
-        }
+            // Derived from the edited rectangles and sent whole, so every
+            //frame in the file is registered before the first stage move
+            // rather than amended one scan at a time, like Nikon Scan does
+            let table = session.update_frames(&saved.frames())?;
+            info!(
+                frames = saved.frames.len(),
+                "boundaries from {}",
+                path.display()
+            );
+            framing::Discovery { table, frames: saved.frames(), thumbnail: None }
+        } else {
+            // Only two of the four mechanisms take a pass to find the frames; the
+            // others read them off a page and would leave a bar claiming a pass was
+            // running. Made on the first report with a length for the same reason
+            // the metering bars are
+            let mut bar = common::PassBar::new("thumbnail");
+            let discovery =
+                framing::discover_with(session, format, film.into(), &mut samples, |p| {
+                    bar.update(p);
+                    if cancel::requested() {
+                        ControlFlow::Break(())
+                    } else {
+                        ControlFlow::Continue(())
+                    }
+                })?;
+            bar.done();
+            discovery
+        };
 
         if save_thumbnail && let Some(pass) = &discovery.thumbnail {
             let path = io::write_thumbnail(&basename, first, &samples, pass)?;
@@ -300,7 +311,7 @@ fn run_cancellable(session: &mut Session, args: cli::Scan) -> anyhow::Result<()>
                             // a length keeps that line off the screen, and names
                             // the bar for the pass it is rather than renaming it
                             if meter_bar.is_none() && p.total > 0 {
-                                meter_bar = Some(pass_bar(format!("meter {pass}"), p.total));
+                                meter_bar = Some(common::pass_bar(format!("meter {pass}"), p.total));
                                 shown = pass;
                             }
                             if let Some(bar) = &meter_bar {
@@ -317,7 +328,7 @@ fn run_cancellable(session: &mut Session, args: cli::Scan) -> anyhow::Result<()>
                                 crate::progress::done(bar);
                             }
                             if scan_bar.is_none() && p.total > 0 {
-                                scan_bar = Some(pass_bar(format!("frame {}", n + 1), p.total));
+                                scan_bar = Some(common::pass_bar(format!("frame {}", n + 1), p.total));
                             }
                             if let Some(bar) = &scan_bar {
                                 bar.report(p);
@@ -377,6 +388,17 @@ fn run_cancellable(session: &mut Session, args: cli::Scan) -> anyhow::Result<()>
             );
         }
 
+        // The boundaries describe this one strip, so a file-driven run stops
+        // here rather than waiting for the next holder
+        if frames_file.is_some() {
+            if !no_eject {
+                let ejected = session.eject()?;
+                if ejected {
+                    info!("ejected");
+                }
+            }
+            break;
+        }
         if no_eject {
             break;
         }
@@ -395,7 +417,7 @@ fn run_cancellable(session: &mut Session, args: cli::Scan) -> anyhow::Result<()>
         // and is also the only one that can say when it has run out
         if framing::self_feeding(session.capabilities()) {
             session.refresh()?;
-            if !ready(session, true)? {
+            if !common::ready(session, true)? {
                 info!("nothing left to load");
                 break;
             }
@@ -407,10 +429,10 @@ fn run_cancellable(session: &mut Session, args: cli::Scan) -> anyhow::Result<()>
         // A unit with no UNLOAD cannot give the medium back, and what the
         // operator does with it is theirs to say: a strip holder is advanced
         // where a mount is swapped, and neither has to leave the gate
-        if !ejected && !confirm("Replace or advance the film, then press Enter")? {
+        if !ejected && !common::confirm("Replace or advance the film, then press Enter")? {
             break;
         }
-        wait_for_film(session, "load the next strip", false)?;
+        common::wait_for_film(session, "load the next strip", false)?;
     }
     Ok(())
 }
@@ -447,143 +469,4 @@ fn hold_white_balance(film: cli::FilmType, unlock: bool, lock: bool) -> bool {
         );
     }
     asked
-}
-
-/// Whether there is film to scan
-///
-/// A feeder or a cartridge keeps its film behind the gate, so nothing reads as
-/// loaded until the unit is told to take some in. `take_in` is whether it may:
-/// false once a medium has been scanned and ejected, where loading again would
-/// only bring the same film back
-fn ready(session: &mut Session, take_in: bool) -> Result<bool, Error> {
-    if session.media_loaded()? {
-        return Ok(true);
-    }
-    if !take_in || !session.load()? {
-        return Ok(false);
-    }
-    // The address page now describes the medium that came in
-    session.refresh()?;
-    session.media_loaded()
-}
-
-/// The same, counting anything the operator can put right as "not yet": an open
-/// door is what the prompt is for
-fn waiting(session: &mut Session, take_in: bool) -> Result<bool, Error> {
-    match ready(session, take_in) {
-        Err(Error::Media(condition)) => {
-            debug!(%condition, "waiting on the operator");
-            Ok(false)
-        }
-        other => other,
-    }
-}
-
-/// [`Session::refresh`], tolerating the medium-not-present it can itself hit:
-/// a strip feeder's gate sits empty between strips, and that is the state this
-/// is called from a loop to wait out, not a failure of the refresh
-fn refresh_while_empty(session: &mut Session) -> Result<(), Error> {
-    match session.refresh() {
-        Ok(()) | Err(Error::Media(_)) => Ok(()),
-        Err(e) => Err(e),
-    }
-}
-
-/// Wait until a holder is loaded, then put the unit in a state to scan from
-fn wait_for_film(session: &mut Session, prompt: &str, take_in: bool) -> anyhow::Result<()> {
-    // An eject leaves what we know about the holder behind, so ask again before
-    // believing anything is in there
-    refresh_while_empty(session)?;
-
-    if !waiting(session, take_in)? {
-        // The spinner is the affordance on a terminal, and hidden anywhere else, so the log says it too
-        info!("{prompt}");
-        let spinner = ProgressBar::with_draw_target(None, ProgressDrawTarget::hidden());
-        spinner.set_style(ProgressStyle::default_spinner());
-        spinner.set_message(format!("{prompt}. Ctrl-c to stop"));
-        let spinner = crate::progress::add(spinner);
-        spinner.enable_steady_tick(SPINNER_TICK);
-        loop {
-            // Nothing is moving while this waits, so stopping here is always safe
-            if cancel::requested() {
-                return Err(Error::Cancelled.into());
-            }
-            std::thread::sleep(HOLDER_POLL);
-            refresh_while_empty(session)?;
-            // Retrying the load is what picks up a supply that was refilled
-            if waiting(session, take_in)? {
-                crate::progress::done(spinner);
-                break;
-            }
-        }
-    }
-    info!("film loaded");
-    session.stage()?;
-    Ok(())
-}
-
-/// Ask the operator for something and wait for them, answering whether anyone
-/// was there to answer. Polls for Ctrl-c on a background reader thread, same
-/// as every other wait
-fn confirm(prompt: &str) -> anyhow::Result<bool> {
-    eprintln!("{prompt}. Ctrl-c to stop");
-    let (tx, rx) = std::sync::mpsc::channel();
-    std::thread::spawn(move || {
-        let mut line = String::new();
-        let _ = tx.send(std::io::stdin().read_line(&mut line).map(|n| n > 0));
-    });
-    loop {
-        if cancel::requested() {
-            return Err(Error::Cancelled.into());
-        }
-        match rx.recv_timeout(HOLDER_POLL) {
-            Ok(answered) => {
-                // The Enter that answered this has been echoed as a line of its
-                // own, so step back over it rather than leaving a blank line
-                let mut err = std::io::stderr().lock();
-                if err.is_terminal() {
-                    let _ = err.write_all(b"\x1b[1A\x1b[2K");
-                }
-                return Ok(answered?);
-            }
-            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
-            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => return Ok(false),
-        }
-    }
-}
-
-/// A bar for one pass
-///
-/// The length is not known until the first chunk arrives, so it starts empty
-/// and learns. Hidden by indicatif when stderr is not a terminal, and drawn no
-/// more than 20 times a second, which is what keeps the callback off the
-/// scanner's back
-fn pass_bar(label: impl Into<Cow<'static, str>>, total: u64) -> ProgressBar {
-    // A bar built the usual way draws straight to stderr, so styling and naming
-    // it here would leave that first line behind the moment `add` moves it onto
-    // the shared draw target. Built hidden, it draws nothing until it is added
-    let bar = ProgressBar::with_draw_target(Some(total), ProgressDrawTarget::hidden());
-    bar.set_style(
-        ProgressStyle::with_template(
-            "{msg:<9} [{bar:30}] {bytes}/{total_bytes}  {bytes_per_sec}  eta {eta}",
-        )
-        .expect("a template of ours")
-        .progress_chars("=> "),
-    );
-    bar.set_message(label.into());
-    crate::progress::add(bar)
-}
-
-/// Moving a pass's progress onto a bar
-trait Report {
-    fn report(&self, progress: Progress);
-}
-
-impl Report for ProgressBar {
-    fn report(&self, progress: Progress) {
-        // The layout's own total, which the cooperative modes can make wrong, so
-        // it is set every time rather than once
-        self.set_length(progress.total);
-        self.set_position(progress.bytes);
-    }
 }

--- a/src/python.rs
+++ b/src/python.rs
@@ -449,6 +449,26 @@ impl PySession {
         Ok(PyDiscovery { frames, thumbnail })
     }
 
+    /// Send an edited set of frame boundaries to the unit as one table
+    ///
+    /// Call this after modifying what [`Session.discover_frames`][Self.discover_frames]
+    /// returned, before scanning. Every rectangle becomes a frame entry, with
+    /// perforation registration derived per top on roll film.
+    #[pyo3(signature = (frames))]
+    fn set_frames(
+        &self,
+        py: Python<'_>,
+        frames: Vec<(u32, u32, u32, u32)>,
+    ) -> PyResult<()> {
+        let rects: Vec<Rect> = frames
+            .into_iter()
+            .map(|(top, left, bottom, right)| Rect { top, left, bottom, right })
+            .collect();
+        py.detach(move || {
+            self.with(|session| session.update_frames(&rects).map(|_| ()))
+        })
+    }
+
     /// Focus, meter, take the pass over `frame`, and optionally clean it
     ///
     /// `frame` is `(top, left, bottom, right)`, one of `discover_frames`'s. `exposures`,

--- a/src/python.rs
+++ b/src/python.rs
@@ -455,18 +455,17 @@ impl PySession {
     /// returned, before scanning. Every rectangle becomes a frame entry, with
     /// perforation registration derived per top on roll film.
     #[pyo3(signature = (frames))]
-    fn set_frames(
-        &self,
-        py: Python<'_>,
-        frames: Vec<(u32, u32, u32, u32)>,
-    ) -> PyResult<()> {
+    fn set_frames(&self, py: Python<'_>, frames: Vec<(u32, u32, u32, u32)>) -> PyResult<()> {
         let rects: Vec<Rect> = frames
             .into_iter()
-            .map(|(top, left, bottom, right)| Rect { top, left, bottom, right })
+            .map(|(top, left, bottom, right)| Rect {
+                top,
+                left,
+                bottom,
+                right,
+            })
             .collect();
-        py.detach(move || {
-            self.with(|session| session.update_frames(&rects).map(|_| ()))
-        })
+        py.detach(move || self.with(|session| session.update_frames(&rects).map(|_| ())))
     }
 
     /// Focus, meter, take the pass over `frame`, and optionally clean it

--- a/src/scan/frame.rs
+++ b/src/scan/frame.rs
@@ -68,6 +68,10 @@ pub fn scan_frame_with(
     samples: &mut Samples,
     mut on: impl FnMut(Phase, Progress) -> ControlFlow<()>,
 ) -> Result<Scanned, Error> {
+    // An edited or hand-made frame needs its transport registration in place
+    // before the first stage move, not after
+    session.ensure_frame_registration(&frame)?;
+
     let mut windows = recipe.windows(session.capabilities(), frame)?;
 
     session.focus_frame(frame, Focus::default())?;

--- a/src/session/data.rs
+++ b/src/session/data.rs
@@ -241,12 +241,16 @@ impl Session {
         };
 
         if !type2 {
-            return Ok(FrameTable::Boundary(data::Boundary { frames: frames.to_vec() }));
+            return Ok(FrameTable::Boundary(data::Boundary {
+                frames: frames.to_vec(),
+            }));
         }
         let mut positions = self.derive_positions(frames)?;
         // Sorted by top, as discovery built the original
         positions.sort_by_key(|f| f.top);
-        Ok(FrameTable::BoundaryType2(BoundaryType2 { frames: positions }))
+        Ok(FrameTable::BoundaryType2(BoundaryType2 {
+            frames: positions,
+        }))
     }
 
     /// Send an edited set of frame boundaries as one table, before any scanning
@@ -264,7 +268,7 @@ impl Session {
     /// Make sure the unit's boundary table carries a registration for `rect`'s
     /// top line, before anything moves toward it
     ///
-    /// Callers that know a whole edited set up front should prefer rebuilding and 
+    /// Callers that know a whole edited set up front should prefer rebuilding and
     /// sending the table once themselves ([`Self::rebuild_table`]); this is the
     /// fallback for callers who arrive one frame at a time.
     pub fn ensure_frame_registration(&mut self, rect: &data::Rect) -> Result<(), Error> {

--- a/src/session/data.rs
+++ b/src/session/data.rs
@@ -231,17 +231,22 @@ impl Session {
 
     /// The boundary table `frames` corresponds to, for the loaded medium
     pub fn rebuild_table(&mut self, frames: &[data::Rect]) -> Result<FrameTable, Error> {
-        match self.frames.as_ref() {
-            Some(FrameTable::Boundary(_)) | None => {
-                Ok(FrameTable::Boundary(data::Boundary { frames: frames.to_vec() }))
-            }
-            Some(FrameTable::BoundaryType2(_)) => {
-                let mut positions = self.derive_positions(frames)?;
-                // Sorted by top, as discovery built the original
-                positions.sort_by_key(|f| f.top);
-                Ok(FrameTable::BoundaryType2(BoundaryType2 { frames: positions }))
-            }
+        // A discovered table decides by being one; no table yet - the
+        // `--frames-file` case, where this session skipped discovery - decides
+        // by what the unit's family speaks, which is also what the flag that
+        // carried through the probe says
+        let type2 = match self.frames.as_ref() {
+            Some(table) => matches!(table, FrameTable::BoundaryType2(_)),
+            None => self.uses_frame_type_2(),
+        };
+
+        if !type2 {
+            return Ok(FrameTable::Boundary(data::Boundary { frames: frames.to_vec() }));
         }
+        let mut positions = self.derive_positions(frames)?;
+        // Sorted by top, as discovery built the original
+        positions.sort_by_key(|f| f.top);
+        Ok(FrameTable::BoundaryType2(BoundaryType2 { frames: positions }))
     }
 
     /// Send an edited set of frame boundaries as one table, before any scanning

--- a/src/session/data.rs
+++ b/src/session/data.rs
@@ -184,6 +184,111 @@ impl Session {
         Ok(())
     }
 
+    /// Derive `FramePosition`s for arbitrary frame tops, registering each
+    /// against the unit's own perforation reading at its address
+    fn derive_positions(
+        &mut self,
+        frames: &[data::Rect],
+    ) -> Result<Vec<data::FramePosition>, Error> {
+        let caps = &self.caps;
+        let origin = caps.address.y_axis.address_range.start;
+        let end = caps.address.y_axis.address_range.last;
+        // The resolution discovery's pass ran at, so an address maps onto the
+        // perforation table with the same column arithmetic that built it
+        let asked = u32::from(caps.address.thumbnail_resolution.start).max(1);
+        let optical_y = u32::from(caps.address.y_axis.optical_dpi)
+            .max(u32::from(caps.address.x_axis.optical_dpi));
+        let pitch = (optical_y / asked).max(1);
+
+        let perfs = self.read_perforations()?;
+        let mut positions = Vec::with_capacity(frames.len());
+        for (n, r) in frames.iter().enumerate() {
+            if r.top < origin || r.top > end {
+                return Err(malformed(format!(
+                    "frame {}: top {} is outside the axis range {origin}..={end}, \
+                     so there is nowhere to register it",
+                    n + 1,
+                    r.top
+                )));
+            }
+            // Nearest column: detection's own tops are exact multiples of the
+            // pitch away from the origin, an edited one may not be
+            let col = ((r.top - origin) + pitch / 2) / pitch;
+            match perfs.at(col as usize) {
+                Some(perf) => positions.push(data::FramePosition::new(r.top, perf)),
+                None => {
+                    return Err(malformed(format!(
+                        "frame {}: no perforation reading at address {} (column {col}), \
+                         so this frame cannot be registered for the transport",
+                        n + 1,
+                        r.top
+                    )));
+                }
+            }
+        }
+        Ok(positions)
+    }
+
+    /// The boundary table `frames` corresponds to, for the loaded medium
+    pub fn rebuild_table(&mut self, frames: &[data::Rect]) -> Result<FrameTable, Error> {
+        match self.frames.as_ref() {
+            Some(FrameTable::Boundary(_)) | None => {
+                Ok(FrameTable::Boundary(data::Boundary { frames: frames.to_vec() }))
+            }
+            Some(FrameTable::BoundaryType2(_)) => {
+                let mut positions = self.derive_positions(frames)?;
+                // Sorted by top, as discovery built the original
+                positions.sort_by_key(|f| f.top);
+                Ok(FrameTable::BoundaryType2(BoundaryType2 { frames: positions }))
+            }
+        }
+    }
+
+    /// Send an edited set of frame boundaries as one table, before any scanning
+    ///
+    /// Returns the table that was sent.
+    pub fn update_frames(&mut self, frames: &[data::Rect]) -> Result<FrameTable, Error> {
+        let table = self.rebuild_table(frames)?;
+        match &table {
+            FrameTable::Boundary(b) => self.set_boundaries(b)?,
+            FrameTable::BoundaryType2(t) => self.set_boundaries_type2(t)?,
+        }
+        Ok(table)
+    }
+
+    /// Make sure the unit's boundary table carries a registration for `rect`'s
+    /// top line, before anything moves toward it
+    ///
+    /// Callers that know a whole edited set up front should prefer rebuilding and 
+    /// sending the table once themselves ([`Self::rebuild_table`]); this is the
+    /// fallback for callers who arrive one frame at a time.
+    pub fn ensure_frame_registration(&mut self, rect: &data::Rect) -> Result<(), Error> {
+        let missing = match self.frames.as_ref() {
+            Some(FrameTable::BoundaryType2(t)) => !t.frames.iter().any(|f| f.top == rect.top),
+            _ => false,
+        };
+        if !missing {
+            return Ok(());
+        }
+
+        // Cloned ahead of the unit round-trip below, which borrows mutably
+        let mut amended = match self.frames.as_ref() {
+            Some(FrameTable::BoundaryType2(t)) => t.clone(),
+            _ => unreachable!("checked above"),
+        };
+        let entry = *self
+            .derive_positions(std::slice::from_ref(rect))?
+            .first()
+            .expect("one frame in, one position out");
+        // Kept sorted by top, as discovery built the original
+        match amended.frames.binary_search_by(|f| f.top.cmp(&rect.top)) {
+            Ok(i) => amended.frames[i] = entry,
+            Err(i) => amended.frames.insert(i, entry),
+        }
+        info!(top = rect.top, "registered an edited frame position");
+        self.set_boundaries_type2(&amended)
+    }
+
     pub fn read_perforations(&mut self) -> Result<data::PerfInformation, Error> {
         let (_, record) = self.read_record(data::DataType::Perforation, 0)?;
         self.test_unit_ready(Duration::from_millis(500))?;


### PR DESCRIPTION
Based on #40, added `nkscan discover` to detect frame boundaries and write them to a JSON file for editing. I opted for JSON for the possibility of simpler integration with UI tooling. Boundaries are calculated when passing the JSON back to `nkscan scan`.  When running `nkscan scan` without a boundaries file the existing flow of detecting + scanning is used. I also lifted out some functions from scan that are also used in the discover routine, and put them in a common file.

It produces a file like this (all addresses are in scanner-space):

```
{
  "product": "LS-50 ED",
  "mechanism": "Perforation",
  "frames": [
    {
      "top": 2173,
      "left": 0,
      "bottom": 7830,
      "right": 3945
    },
...
    {
      "top": 219473,
      "left": 0,
      "bottom": 225130,
      "right": 3945
    },
    {
      "top": 225336,
      "left": 0,
      "bottom": 230993,
      "right": 3945
    }
  ]
}
```

Python bindings are also added. `set_frames` derives boundaries from supplied rects and sends them to the scanner. Upstream Python consumers can freely modify the tuples returned, the library will take care of converting them to Boundary data. When calling `scan_frame` after `set_frames`, supplied boundary data is used; without `set_frames` retains the existing behaviour. 

Should also just work on 8K/9K since there's no boundary recalculation in play there but I cannot test that, hence the draft. Again, feel free to poke holes and complain about my abuse of the language, although I feel like I'm slowly starting to understand why people are raving about it I do still have to rely on LLM assistance for semantics I'll die here on my C hill full of segfaults ;)