### PR TITLE
put a frame where the thumbnail found it on a perforation-framed unit

### DIFF
--- a/nkscan.pyi
+++ b/nkscan.pyi
@@ -256,13 +256,16 @@ class Session:
         works the same as a detected one, just slower if the stage has to home
         first to reach it
         """
-    def scan_frame(self, frame: tuple[builtins.int, builtins.int, builtins.int, builtins.int], dpi: typing.Optional[builtins.int] = None, samples: builtins.int = 1, superfine: builtins.bool = False, infrared: builtins.bool = False, clean: builtins.bool = False, lock_white_balance: builtins.bool = True, exposures: typing.Optional[typing.Mapping[builtins.str, builtins.int]] = None, progress: typing.Optional[typing.Any] = None) -> ScanResult:
+    def scan_frame(self, frame: tuple[builtins.int, builtins.int, builtins.int, builtins.int], dpi: typing.Optional[builtins.int] = None, samples: builtins.int = 1, superfine: builtins.bool = False, infrared: builtins.bool = False, clean: builtins.bool = False, lock_white_balance: builtins.bool = True, exposures: typing.Optional[typing.Mapping[builtins.str, builtins.int]] = None, progress: typing.Optional[typing.Any] = None, frames: typing.Optional[typing.Sequence[tuple[builtins.int, builtins.int, builtins.int, builtins.int]]] = None) -> ScanResult:
         r"""
         Focus, meter, take the pass over `frame`, and optionally clean it
         
-        `frame` is `(top, left, bottom, right)`, one of `discover_frames`'s. `exposures`,
-        keyed the way `ScanResult.exposures` is, reuses an exposure already decided
-        rather than metering this frame fresh
+        `frame` is `(top, left, bottom, right)`, one of `discover_frames`'s, or one of them
+        moved or cropped. `exposures`, keyed the way `ScanResult.exposures` is, reuses an
+        exposure already decided rather than metering this frame fresh. `frames` is
+        `discover_frames`'s whole list: a unit that positions the film by its frame table
+        honours that table only as a whole, so a session that did not measure the strip
+        needs it back before a moved or cropped frame can be put where it asks
         """
     def close(self) -> None:
         r"""

--- a/src/protocol/data.rs
+++ b/src/protocol/data.rs
@@ -519,6 +519,25 @@ impl BoundaryType2 {
     /// Bytes occupied by each boundary record.
     const BOUNDARY: usize = 8;
 
+    /// Put `frame` in the slot its top falls in, so a SET WINDOW at that top
+    /// picks it
+    ///
+    /// The unit reads a window inside the frame whose entry has the greatest
+    /// top at or under the window's, so a nudged top replaces that entry rather
+    /// than joining the table, whose length the holder's frame count caps. A
+    /// top ahead of every entry takes the first slot. Order is kept either way
+    pub fn register(&mut self, frame: FramePosition) {
+        let slot = self
+            .frames
+            .iter()
+            .rposition(|f| f.top <= frame.top)
+            .unwrap_or(0);
+        match self.frames.get_mut(slot) {
+            Some(entry) => *entry = frame,
+            None => self.frames.push(frame),
+        }
+    }
+
     pub fn from_bytes(b: &[u8]) -> Option<Self> {
         let head: &[u8; Self::HEAD] = b.get(..Self::HEAD)?.try_into().ok()?;
 
@@ -978,6 +997,29 @@ impl Header {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A nudged top replaces the entry it falls under, so the table stays the
+    /// length the holder allows and stays in order
+    #[test]
+    fn a_registered_top_takes_the_slot_it_falls_in() {
+        let perf = PerforationInformation::default();
+        let at = |top| FramePosition::new(top, &perf);
+        let tops = |table: &BoundaryType2| table.frames.iter().map(|f| f.top).collect::<Vec<_>>();
+        let mut table = BoundaryType2 {
+            frames: vec![at(100), at(200), at(300)],
+        };
+
+        table.register(at(250));
+        assert_eq!(tops(&table), [100, 250, 300]);
+        table.register(at(50));
+        assert_eq!(tops(&table), [50, 250, 300]);
+        table.register(at(900));
+        assert_eq!(tops(&table), [50, 250, 900]);
+
+        let mut empty = BoundaryType2::default();
+        empty.register(at(7));
+        assert_eq!(tops(&empty), [7]);
+    }
 
     /// A frame detected on line 2 seeks by line 2's own reading
     #[test]

--- a/src/python.rs
+++ b/src/python.rs
@@ -451,9 +451,12 @@ impl PySession {
 
     /// Focus, meter, take the pass over `frame`, and optionally clean it
     ///
-    /// `frame` is `(top, left, bottom, right)`, one of `discover_frames`'s. `exposures`,
-    /// keyed the way `ScanResult.exposures` is, reuses an exposure already decided
-    /// rather than metering this frame fresh
+    /// `frame` is `(top, left, bottom, right)`, one of `discover_frames`'s, or one of them
+    /// moved or cropped. `exposures`, keyed the way `ScanResult.exposures` is, reuses an
+    /// exposure already decided rather than metering this frame fresh. `frames` is
+    /// `discover_frames`'s whole list: a unit that positions the film by its frame table
+    /// honours that table only as a whole, so a session that did not measure the strip
+    /// needs it back before a moved or cropped frame can be put where it asks
     #[pyo3(signature = (
         frame,
         dpi=None,
@@ -464,6 +467,7 @@ impl PySession {
         lock_white_balance=true,
         exposures=None,
         progress=None,
+        frames=None,
     ))]
     #[allow(clippy::too_many_arguments)]
     fn scan_frame(
@@ -478,14 +482,16 @@ impl PySession {
         lock_white_balance: bool,
         exposures: Option<HashMap<String, u32>>,
         progress: Option<Py<PyAny>>,
+        frames: Option<Vec<(u32, u32, u32, u32)>>,
     ) -> PyResult<PyScanResult> {
-        let (top, left, bottom, right) = frame;
-        let frame = Rect {
+        let rect = |(top, left, bottom, right): (u32, u32, u32, u32)| Rect {
             top,
             left,
             bottom,
             right,
         };
+        let frame = rect(frame);
+        let frames: Vec<Rect> = frames.unwrap_or_default().into_iter().map(rect).collect();
 
         let locked = exposures.map(|by_name| {
             let mut e = Exposures::default();
@@ -497,6 +503,7 @@ impl PySession {
 
         py.detach(move || {
             self.with(|session| {
+                framing::remember(session, &frames)?;
                 let caps = session.capabilities();
                 let dpi = dpi.unwrap_or(caps.address.x_axis.optical_dpi);
                 let interleaving = if superfine || !caps.reads_lines_at_once_at(dpi) {

--- a/src/scan/frame.rs
+++ b/src/scan/frame.rs
@@ -7,6 +7,7 @@ use crate::{
         autoexpose::Exposures,
         clean::clean_frame,
         focus::Focus,
+        framing,
         pass::{Pass, Progress},
         window::Recipe,
     },
@@ -70,6 +71,7 @@ pub fn scan_frame_with(
 ) -> Result<Scanned, Error> {
     let mut windows = recipe.windows(session.capabilities(), frame)?;
 
+    framing::register(session, frame)?;
     session.focus_frame(frame, Focus::default())?;
 
     let exposures = match options.exposures {

--- a/src/scan/framing.rs
+++ b/src/scan/framing.rs
@@ -11,7 +11,9 @@ use crate::{
     error::Error,
     protocol::{
         caps::{Capabilities, address::CoordinateBase, film::FilmFormat, other::DataTypes},
-        data::{Boundary, FrameTable, Op, Rect},
+        data::{
+            Boundary, BoundaryType2, FramePosition, FrameTable, Op, PerforationInformation, Rect,
+        },
         decode::Samples,
     },
     session::Session,
@@ -175,6 +177,78 @@ pub fn frames(caps: &Capabilities) -> Result<Boundary, Error> {
         })
         .collect();
     Ok(Boundary { frames })
+}
+
+/// Register `frame` with the unit before a pass over it, where the unit
+/// positions the film by its table rather than by the window
+///
+/// A perforation-framed unit moves the film to the perforation record of the
+/// table entry a SET WINDOW Y falls under and reads the window inside that
+/// frame's gate, so a rectangle off the table - a nudged frame, a crop - is
+/// read as an offset into whatever frame it fell under and blacks out past the
+/// gate. Writing the record of the rectangle's own thumbnail line into the slot
+/// its top falls under moves the film there instead. The unit only honours a
+/// table as a whole, so this starts from the table the session knows, from
+/// discovery or from [`remember`], and does nothing where there is none; a top
+/// already in that table is left alone, and every other mechanism addresses the
+/// window itself and needs nothing here
+pub fn register(session: &mut Session, frame: Rect) -> Result<(), Error> {
+    if Framing::choose(session.capabilities()) != Framing::Perforation {
+        return Ok(());
+    }
+    let Some(mut table) = session.frames_type2().cloned() else {
+        return Ok(());
+    };
+    if table.frames.iter().any(|f| f.top == frame.top) {
+        return Ok(());
+    }
+
+    let (line, perf) = record(session, frame.top)?;
+    table.register(FramePosition::new(frame.top, &perf));
+    debug!(
+        top = frame.top,
+        line,
+        ?perf,
+        "registered a frame off the table"
+    );
+    session.set_boundaries_type2(&table)
+}
+
+/// Give a session that did not measure the strip the frames discovery found
+///
+/// The unit keeps the last thumbnail's perforation table but refuses to read
+/// its frame table back, and honours a table only as a whole, so a session
+/// opened after discovery has to be handed the frames to write it again. Only a
+/// perforation-framed unit needs this, and a session that already knows a
+/// table keeps it
+pub fn remember(session: &mut Session, frames: &[Rect]) -> Result<(), Error> {
+    if Framing::choose(session.capabilities()) != Framing::Perforation
+        || session.frames_type2().is_some()
+        || frames.is_empty()
+    {
+        return Ok(());
+    }
+    let mut table = BoundaryType2::default();
+    for frame in frames {
+        let (_, perf) = record(session, frame.top)?;
+        table.frames.push(FramePosition::new(frame.top, &perf));
+    }
+    debug!(frames = table.frames.len(), "wrote the frame table back");
+    session.set_boundaries_type2(&table)
+}
+
+/// The perforation record that lands a frame with its top at `top`
+fn record(session: &mut Session, top: u32) -> Result<(usize, PerforationInformation), Error> {
+    let line = thumbnail::line_at(session.capabilities(), top) + thumbnail::PERFORATION_LEAD;
+    let perfs = session.read_perforations()?;
+    let perf = perfs.at(line).ok_or_else(|| Error::Unsupported {
+        op: "frame registration",
+        reason: format!(
+            "a frame at {top} needs the perforation reading of thumbnail line {line}, and the last pass measured {}",
+            perfs.perfs.len()
+        ),
+    })?;
+    Ok((line, perf.clone()))
 }
 
 /// The discovered frame table, however that happened.

--- a/src/scan/thumbnail.rs
+++ b/src/scan/thumbnail.rs
@@ -40,7 +40,28 @@ const MARGIN: u32 = 50;
 /// SA-21, where a line is 6 encoder pulses: the scan of a detected rectangle
 /// opened on 164 addresses of the gap ahead of the picture, and with the lead
 /// applied on the picture's edge
-const PERFORATION_LEAD: usize = 4;
+pub(crate) const PERFORATION_LEAD: usize = 4;
+
+/// Stage addresses one thumbnail column spans
+///
+/// The pass asks for the thumbnail resolution, and a thumbnail pitch is the
+/// optical resolution over what was asked, rounded down, so this is the pass's
+/// own `line_pitch` without the pass in hand
+pub(crate) fn line_pitch(caps: &Capabilities) -> u32 {
+    let optical =
+        u32::from(caps.address.y_axis.optical_dpi).max(u32::from(caps.address.x_axis.optical_dpi));
+    match u32::from(caps.address.thumbnail_resolution.start) {
+        0 => 1,
+        asked => (optical / asked).max(1),
+    }
+}
+
+/// The thumbnail line nearest a Y address
+pub(crate) fn line_at(caps: &Capabilities, y: u32) -> usize {
+    let pitch = line_pitch(caps);
+    let origin = caps.address.y_axis.address_range.start;
+    ((y.saturating_sub(origin) + pitch / 2) / pitch) as usize
+}
 
 /// Whether this unit and adapter will thumbnail at all
 ///

--- a/src/scan/thumbnail.rs
+++ b/src/scan/thumbnail.rs
@@ -31,6 +31,17 @@ use tracing::*;
 /// The most film to leave either side of a frame, as the format over this
 const MARGIN: u32 = 50;
 
+/// Lines a frame lands ahead of the perforation record the unit is handed for it
+///
+/// Positioned by a record, the unit puts the scan window's first line this many
+/// thumbnail lines before the line the record was read at, on every frame and
+/// at every offset within one, so the record that lands a frame where the
+/// thumbnail found it is this many lines on. Measured on an LS-50 with the
+/// SA-21, where a line is 6 encoder pulses: the scan of a detected rectangle
+/// opened on 164 addresses of the gap ahead of the picture, and with the lead
+/// applied on the picture's edge
+const PERFORATION_LEAD: usize = 4;
+
 /// Whether this unit and adapter will thumbnail at all
 ///
 /// Support follows the adapter rather than the model, so this is re-decided
@@ -159,7 +170,7 @@ pub fn frames_type2(
         .iter()
         .filter_map(|&col| {
             let top = origin + col as u32 * pitch;
-            let perf = perf_info.at(col);
+            let perf = perf_info.at(col + PERFORATION_LEAD);
             debug!(col, top, ?perf, "detected column");
             if top + length > end {
                 // A column with no reading is one the stage cannot be sent to


### PR DESCRIPTION
I was adding per-frame offsets to NegPy's strip preview and the LS-50 scans (SA-21) kept coming back off from the preview. The preview is cut out of the thumbnail at the same rect the scan gets, so they should match. They didn't, for two reasons.

1) Every scan starts 4 thumbnail lines (164 addresses at 4000 dpi) before its detected column. The columns are right against the thumbnail, so each scan opens on about 1 mm of gap and drops the same off the tail. Handing the unit the perforation record 4 lines later fixes it. I only have this one unit, so I don't know where the 4 comes from.

2) a rect that isn't in the table (a shifted frame, a crop) is read as an offset into whatever table frame its Y lands in, inside that frame's gate. Past the gate the stage parks and repeats a line, and shift backwards and you get the previous frame's tail. The unit won't read its table back (05h-24h, even with BOUNDARY2_READ advertised) and only takes a table whole. One entry from a fresh session did nothing, all six moved the film. So register puts the rect's own record in the slot its top lands in, and scan_frame in Python takes frames= so a session that didn't run the discovery can rewrite the table from the perforation memory the unit keeps.

+/-8 mm on a frame now comes back whole and lined up with the thumbnail. Before, both blacked out past the gate.

examples of wrong behaviour before that fix (big per-frame offset applied for better demonstration)
https://github.com/marcinz606/NegPy/pull/1042

and example after the fix:
<img width="1184" height="828" alt="20260906_18h39m59s_grim" src="https://github.com/user-attachments/assets/7f4c00f5-ccf7-40e2-a0d3-c14972caeddf" />
excessive offset is applied as expected and cuts into next frame instead of scan entering "hyperspeed" 


Disclosure: debugged and implemented with help of Claude Fable 5.1

